### PR TITLE
fix: Fix lexer bug

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
   },
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "quickfix.biome": true,
-    "source.organizeImports.biome": true
+    "quickfix.biome": "explicit",
+    "source.organizeImports.biome": "explicit"
   }
 }

--- a/src/transformers/LexerTransformer.ts
+++ b/src/transformers/LexerTransformer.ts
@@ -142,8 +142,7 @@ export class LexerTransformer extends TransformStream<string, Token> {
 
     // Check for Quoted String
     if (this.#buffer.startsWith(this.#quotation)) {
-      // If we're flushing and the buffer doesn't end with a quote, then return null
-      // because we're not done with the quoted string
+      // If not flushing and the buffer doesn't end with a quote, then return null.
       if (flush === false && this.#buffer.endsWith(this.#quotation)) {
         return null;
       }

--- a/src/transformers/__tests__/LexerTransformer.spec.ts
+++ b/src/transformers/__tests__/LexerTransformer.spec.ts
@@ -226,6 +226,14 @@ describe("LexerTransformer", () => {
               chunks: ["ccc2", "1", "c"],
             },
           ],
+          [
+            // field and quotation are the same, and chunks are separated by field enclosures.
+            {
+              quotation: "key",
+              row: ["key"],
+              chunks: ["keykeyk", "eykey"],
+            },
+          ],
         ],
       },
     ));


### PR DESCRIPTION
Field and quotation marks are the same and chunks are properly value in cases where the field is delimited by a field enclosure fixed the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Modified settings to adjust code actions on save for a more explicit user experience.

- **Bug Fixes**
  - Enhanced the `extractQuotedString` method in text processing to handle specific conditions more accurately.

- **Tests**
  - Introduced new test cases to ensure reliable field enclosures and data chunk separation in text processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->