### PR TITLE
Reorder exports in package.json

### DIFF
--- a/.changeset/pink-monkeys-laugh.md
+++ b/.changeset/pink-monkeys-laugh.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": patch
+---
+
+Reorder exports in package.json

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "exports": {
     ".": {
-      "default": "./lib/index.js",
-      "types": "./lib/index.d.ts"
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION

- `"default"` key should be the last in the object so it doesn't take precedence over the keys following it.
- `"types"` key should be the first in the object as required by TypeScript.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
    - Improved the organization of toolbox features for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->