### PR TITLE
Update release.yaml workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,11 +2,11 @@ name: Release
 
 on:
   # Run this workflow when a workflow_run event is triggered
-  # from the "Node.js CI", "Deno CI", or "Browser CI" workflows
+  # from the "Node.js CI" workflows
   # and the workflow_run's status is "completed"
   # and the workflow_run's base branch is "main".
   workflow_run:
-    workflows: [Node.js CI, Deno CI, Browser CI]
+    workflows: [Node.js CI]
     branches: [main]
     types: [completed]
 
@@ -36,6 +36,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    needs: build
     # Only run this job if the workflow_run's conclusion was "success"
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
@@ -53,6 +54,8 @@ jobs:
       - name: Install Dependencies
         run: npm ci
       - uses: actions/download-artifact@v4
+        with:
+          path: dist
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
@@ -82,8 +85,9 @@ jobs:
           cache: npm
       - name: Install Dependencies
         run: npm ci
-      - name: Build
-        run: npm run build
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
       - name: Creating .npmrc
         if: ${{ github.actor != 'dependabot[bot]' }}
         run: |


### PR DESCRIPTION
This commit updates the release.yaml workflow to only trigger on the "Node.js CI" workflow and adds a dependency on the "build" job. It also includes a step to download the "dist" artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the release workflow to depend on "Node.js CI" and streamlined the process by using build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->