### PR TITLE
Add file inclusion patterns to biome.json

### DIFF
--- a/.changeset/cool-emus-smile.md
+++ b/.changeset/cool-emus-smile.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": patch
+---
+
+Add file inclusion patterns to biome.json

--- a/biome.json
+++ b/biome.json
@@ -5,6 +5,9 @@
     "clientKind": "git",
     "useIgnoreFile": true
   },
+  "files": {
+    "include": ["**/*.{js,ts,json}"]
+  },
   "organizeImports": {
     "enabled": true
   },


### PR DESCRIPTION
This pull request adds file inclusion patterns to the biome.json file. The inclusion patterns specify which files should be included in the project, based on their file extensions. This change allows for better organization and management of the project files.