### PR TITLE
Add custom file naming for different formats in vite.config.ts

### DIFF
--- a/.changeset/nice-games-sleep.md
+++ b/.changeset/nice-games-sleep.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": patch
+---
+
+Add custom file naming for different formats in vite.config.ts

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
       entry: "src/web-csv-toolbox.ts",
       name: "CSV",
       formats: ["es", "cjs"],
+      fileName: (format, entryName) => {
+        const ext = format === "cjs" ? "cjs" : "js";
+        return `${format}/${entryName}.${ext}`;
+      },
     },
     minify: "terser",
     sourcemap: true,
@@ -16,7 +20,6 @@ export default defineConfig({
         inlineDynamicImports: false,
         preserveModules: true,
         preserveModulesRoot: "src",
-        entryFileNames: "[format]/[name].js",
       },
     },
   },


### PR DESCRIPTION
This pull request adds custom file naming for different formats in the `vite.config.ts` file. Previously, the entry file names were set using the `[format]/[name].js` pattern. With this change, a custom file naming function is added to the `vite.config.ts` file, which allows for different file names based on the format and entry name. This provides more flexibility and control over the generated file names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the output file naming mechanism for improved flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->