### PR TITLE
Add provenance to publishConfig in package.json

### DIFF
--- a/.changeset/sharp-worms-divide.md
+++ b/.changeset/sharp-worms-divide.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": patch
+---
+
+Add provenance to publishConfig in package.json

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -58,6 +58,7 @@ jobs:
     permissions:
       contents: write # Used to commit to "Version Packages" PR
       pull-requests: write # Used to create "Version Packages" PR
+      id-token: write # Used to publish to npm with provenance statements
       # Other permissions are defaulted to none
     steps:
       - name: Checkout Repo
@@ -92,6 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     needs: release
     if: needs.release.outputs.published == 'false'
     steps:

--- a/package.json
+++ b/package.json
@@ -82,6 +82,9 @@
   "bugs": {
     "url": "https://github.com/kamiazya/web-csv-toolbox/issues"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "homepage": "https://kamiazya.github.io/web-csv-toolbox/",
   "devDependencies": {
     "@biomejs/biome": "1.5.3",


### PR DESCRIPTION
This pull request adds the "provenance" property to the "publishConfig" object in the package.json file. This change ensures that the provenance information is included when publishing the package.

See https://docs.npmjs.com/generating-provenance-statements for detail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the "web-csv-toolbox" package by ensuring the provenance of published configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->