### PR TITLE
Add FOSSA scan and test workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,23 @@ jobs:
           comment_tag: artefact_comparison_report
           mode: recreate
 
+  fossa_scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Code"
+        uses: actions/checkout@v3
+
+      - name: "Run FOSSA Scan"
+        uses: fossas/fossa-action@f61a4c0c263690f2ddb54b9822a719c25a7b608f # v1.3.1
+        with:
+          api-key: ${{secrets.FOSSA_API_KEY}}
+
+      - name: "Run FOSSA Test"
+        uses: fossas/fossa-action@f61a4c0c263690f2ddb54b9822a719c25a7b608f # v1.3.1
+        with:
+          api-key: ${{secrets.FOSSA_API_KEY}}
+          run-tests: true
+
   test_nodejs:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
This pull request adds FOSSA scan and test workflows to the repository. The FOSSA scan workflow checks for any potential licensing issues in the codebase, while the FOSSA test workflow runs tests to ensure the code is functioning correctly. This addition enhances the overall quality and compliance of the project.