### PR TITLE
Fix artefacts summary generation condition

### DIFF
--- a/.github/workflows/.build.yaml
+++ b/.github/workflows/.build.yaml
@@ -46,12 +46,14 @@ jobs:
             !web-csv-toolbox-wasm/Cargo.lock
             !web-csv-toolbox-wasm/.gitignore
       - name: Generate artefacts summary
+        if: ${{ github.repository == 'kamiazya/web-csv-toolbox' }}
         id: artefacts-summary
         run: |
           echo "ARTEFACTS_SUMMARY<<EOF" >> $GITHUB_OUTPUT
           find dist/ -type f -exec sha512sum {} \; | sed 's/  /,/' | cat <(echo 'sha512,file_name') - >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Add the artefacts summary as a git notes
+        if: ${{ github.repository == 'kamiazya/web-csv-toolbox' }}
         run: |
           git fetch origin refs/notes/*:refs/notes/*
           git config user.name "GitHub Action"


### PR DESCRIPTION
Fixes the condition for generating the artefacts summary in the web-csv-toolbox repository. Previously, the condition was not properly checking the repository name, causing the artefacts summary to be generated for all repositories. This PR adds a check to ensure that the artefacts summary is only generated for the web-csv-toolbox repository.