### PR TITLE
Pined license year action versions

### DIFF
--- a/.changeset/purple-wombats-clap.md
+++ b/.changeset/purple-wombats-clap.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": patch
+---
+
+Pined license year action versions

--- a/.github/workflows/update-license-year.yaml
+++ b/.github/workflows/update-license-year.yaml
@@ -8,7 +8,7 @@ jobs:
   update-license-year:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: FantasticFiasco/action-update-license-year@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: FantasticFiasco/action-update-license-year@9135da8f9ccc675217e02357c744b6b541d45cb0 # 3.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the versions of the license year action used in the workflow. 