### PR TITLE
Update import statements to use type imports

### DIFF
--- a/.changeset/giant-candles-cheer.md
+++ b/.changeset/giant-candles-cheer.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": patch
+---
+
+Update import statements to use type imports

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "build:js": "vite build",
     "build:browser": "vite build --config config/vite.config.umd.ts",
     "serve": "vite serve",
-    "prepare": "husky"
+    "prepare": "husky",
+    "format": "biome check --apply ."
   },
   "repository": {
     "type": "git",

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -1,6 +1,6 @@
 import { assertCommonOptions } from "./assertCommonOptions.ts";
 import { Field, FieldDelimiter, RecordDelimiter } from "./common/constants.ts";
-import { CommonOptions, Token } from "./common/types.ts";
+import type { CommonOptions, Token } from "./common/types.ts";
 import { COMMA, CRLF, DOUBLE_QUOTE, LF } from "./constants.ts";
 import { escapeRegExp } from "./utils/escapeRegExp.ts";
 

--- a/src/LexerTransformer.ts
+++ b/src/LexerTransformer.ts
@@ -1,5 +1,5 @@
 import { Lexer } from "./Lexer.ts";
-import { CommonOptions, Token } from "./common/types.ts";
+import type { CommonOptions, Token } from "./common/types.ts";
 
 /**
  * A transform stream that converts a stream of tokens into a stream of rows.

--- a/src/RecordAssembler.spec.ts
+++ b/src/RecordAssembler.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { RecordAssembler } from "./RecordAssembler.ts";
 import { FC } from "./__tests__/helper.ts";
 import { Field, FieldDelimiter, RecordDelimiter } from "./common/constants.ts";
-import { Token } from "./common/types.ts";
+import type { Token } from "./common/types.ts";
 
 describe("class RecordAssembler", () => {
   it("should throw an error for empty headers", () => {

--- a/src/RecordAssembler.ts
+++ b/src/RecordAssembler.ts
@@ -1,5 +1,9 @@
 import { FieldDelimiter, RecordDelimiter } from "./common/constants.ts";
-import { CSVRecord, RecordAssemblerOptions, Token } from "./common/types.ts";
+import type {
+  CSVRecord,
+  RecordAssemblerOptions,
+  Token,
+} from "./common/types.ts";
 
 export class RecordAssembler<Header extends ReadonlyArray<string>> {
   #fieldIndex = 0;

--- a/src/RecordAssemblerTransformer.spec.ts
+++ b/src/RecordAssemblerTransformer.spec.ts
@@ -3,7 +3,7 @@ import { describe as describe_, expect, it as it_ } from "vitest";
 import { RecordAssemblerTransformer } from "./RecordAssemblerTransformer.ts";
 import { FC, transform } from "./__tests__/helper.ts";
 import { Field, FieldDelimiter, RecordDelimiter } from "./common/constants.ts";
-import { Token } from "./common/types.ts";
+import type { Token } from "./common/types.ts";
 
 const describe = describe_.concurrent;
 const it = it_.concurrent;

--- a/src/RecordAssemblerTransformer.ts
+++ b/src/RecordAssemblerTransformer.ts
@@ -1,5 +1,9 @@
 import { RecordAssembler } from "./RecordAssembler.ts";
-import { CSVRecord, RecordAssemblerOptions, Token } from "./common/types.ts";
+import type {
+  CSVRecord,
+  RecordAssemblerOptions,
+  Token,
+} from "./common/types.ts";
 
 /**
  * A transform stream that converts a stream of tokens into a stream of rows.

--- a/src/assertCommonOptions.ts
+++ b/src/assertCommonOptions.ts
@@ -1,4 +1,4 @@
-import { CommonOptions } from "./common/types.ts";
+import type { CommonOptions } from "./common/types.ts";
 import { CR, LF } from "./constants.ts";
 
 /**

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,4 +1,4 @@
-import { Field, FieldDelimiter, RecordDelimiter } from "./constants.ts";
+import type { Field, FieldDelimiter, RecordDelimiter } from "./constants.ts";
 
 /**
  * Field token type.

--- a/src/convertBinaryToString.ts
+++ b/src/convertBinaryToString.ts
@@ -1,4 +1,4 @@
-import { ParseBinaryOptions } from "./common/types.ts";
+import type { ParseBinaryOptions } from "./common/types.ts";
 
 export function convertBinaryToString<Header extends ReadonlyArray<string>>(
   binary: Uint8Array | ArrayBuffer,

--- a/src/escapeField.ts
+++ b/src/escapeField.ts
@@ -1,5 +1,5 @@
-import { type assertCommonOptions } from "./assertCommonOptions.ts";
-import { CommonOptions } from "./common/types.ts";
+import type { assertCommonOptions } from "./assertCommonOptions.ts";
+import type { CommonOptions } from "./common/types.ts";
 import { COMMA, DOUBLE_QUOTE } from "./constants.ts";
 import { occurrences } from "./utils/occurrences.ts";
 

--- a/src/getOptionsFromResponse.ts
+++ b/src/getOptionsFromResponse.ts
@@ -1,4 +1,4 @@
-import { ParseBinaryOptions } from "./common/types.ts";
+import type { ParseBinaryOptions } from "./common/types.ts";
 import { parseMime } from "./utils/parseMime.ts";
 
 export function getOptionsFromResponse<Header extends ReadonlyArray<string>>(

--- a/src/loadWASM.ts
+++ b/src/loadWASM.ts
@@ -1,4 +1,4 @@
-import init, { InitInput } from "web-csv-toolbox-wasm";
+import init, { type InitInput } from "web-csv-toolbox-wasm";
 
 import dataURL from "web-csv-toolbox-wasm/web_csv_toolbox_wasm_bg.wasm";
 

--- a/src/loadWASM.web.ts
+++ b/src/loadWASM.web.ts
@@ -1,4 +1,4 @@
-import init, { InitInput } from "web-csv-toolbox-wasm";
+import init, { type InitInput } from "web-csv-toolbox-wasm";
 
 /**
  * Load WASM module.

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CSV,
   CSVBinary,
   CSVRecord,

--- a/src/parseBinary.ts
+++ b/src/parseBinary.ts
@@ -1,4 +1,4 @@
-import { CSVRecord, ParseBinaryOptions } from "./common/types.ts";
+import type { CSVRecord, ParseBinaryOptions } from "./common/types.ts";
 import { parseBinaryToArraySync } from "./parseBinaryToArraySync.ts";
 import { parseBinaryToIterableIterator } from "./parseBinaryToIterableIterator.ts";
 import { parseBinaryToStream } from "./parseBinaryToStream.ts";

--- a/src/parseBinaryToArraySync.ts
+++ b/src/parseBinaryToArraySync.ts
@@ -1,4 +1,4 @@
-import { CSVRecord, ParseBinaryOptions } from "./common/types.ts";
+import type { CSVRecord, ParseBinaryOptions } from "./common/types.ts";
 import { convertBinaryToString } from "./convertBinaryToString.ts";
 import { parseStringToArraySync } from "./parseStringToArraySync.ts";
 

--- a/src/parseBinaryToIterableIterator.ts
+++ b/src/parseBinaryToIterableIterator.ts
@@ -1,4 +1,4 @@
-import { CSVRecord, ParseBinaryOptions } from "./common/types.ts";
+import type { CSVRecord, ParseBinaryOptions } from "./common/types.ts";
 import { convertBinaryToString } from "./convertBinaryToString.ts";
 import { parseStringToIterableIterator } from "./parseStringToIterableIterator.ts";
 

--- a/src/parseBinaryToStream.ts
+++ b/src/parseBinaryToStream.ts
@@ -1,4 +1,4 @@
-import { CSVRecord, ParseBinaryOptions } from "./common/types.ts";
+import type { CSVRecord, ParseBinaryOptions } from "./common/types.ts";
 import { convertBinaryToString } from "./convertBinaryToString.ts";
 import { parseStringToStream } from "./parseStringToStream.ts";
 

--- a/src/parseResponse.ts
+++ b/src/parseResponse.ts
@@ -1,4 +1,4 @@
-import { CSVRecord, ParseOptions } from "./common/types.ts";
+import type { CSVRecord, ParseOptions } from "./common/types.ts";
 import { getOptionsFromResponse } from "./getOptionsFromResponse.ts";
 import { parseResponseToStream } from "./parseResponseToStream.ts";
 import { parseUint8ArrayStream } from "./parseUint8ArrayStream.ts";

--- a/src/parseResponseToStream.ts
+++ b/src/parseResponseToStream.ts
@@ -1,4 +1,4 @@
-import { CSVRecord, ParseBinaryOptions } from "./common/types.ts";
+import type { CSVRecord, ParseBinaryOptions } from "./common/types.ts";
 import { getOptionsFromResponse } from "./getOptionsFromResponse.ts";
 import { parseUint8ArrayStreamToStream } from "./parseUint8ArrayStreamToStream.ts";
 

--- a/src/parseString.ts
+++ b/src/parseString.ts
@@ -1,4 +1,4 @@
-import { CSVRecord, ParseOptions } from "./common/types.ts";
+import type { CSVRecord, ParseOptions } from "./common/types.ts";
 import { parseStringToArraySync } from "./parseStringToArraySync.ts";
 import { parseStringToIterableIterator } from "./parseStringToIterableIterator.ts";
 import { parseStringToStream } from "./parseStringToStream.ts";

--- a/src/parseStringStream.ts
+++ b/src/parseStringStream.ts
@@ -1,4 +1,4 @@
-import { CSVRecord, ParseOptions } from "./common/types.ts";
+import type { CSVRecord, ParseOptions } from "./common/types.ts";
 import { parseStringStreamToStream } from "./parseStringStreamToStream.ts";
 import { convertStreamToAsyncIterableIterator } from "./utils/convertStreamToAsyncIterableIterator.ts";
 import * as internal from "./utils/convertThisAsyncIterableIteratorToArray.ts";

--- a/src/parseStringStreamToStream.ts
+++ b/src/parseStringStreamToStream.ts
@@ -1,6 +1,6 @@
 import { LexerTransformer } from "./LexerTransformer.ts";
 import { RecordAssemblerTransformer } from "./RecordAssemblerTransformer.ts";
-import { CSVRecord, ParseOptions } from "./common/types.ts";
+import type { CSVRecord, ParseOptions } from "./common/types.ts";
 import { pipeline } from "./utils/pipeline.ts";
 
 export function parseStringStreamToStream<Header extends ReadonlyArray<string>>(

--- a/src/parseStringToArraySync.ts
+++ b/src/parseStringToArraySync.ts
@@ -1,6 +1,6 @@
 import { Lexer } from "./Lexer.ts";
 import { RecordAssembler } from "./RecordAssembler.ts";
-import { CSVRecord, ParseOptions } from "./common/types.ts";
+import type { CSVRecord, ParseOptions } from "./common/types.ts";
 
 export function parseStringToArraySync<Header extends ReadonlyArray<string>>(
   csv: string,

--- a/src/parseStringToArraySyncWASM.ts
+++ b/src/parseStringToArraySyncWASM.ts
@@ -1,7 +1,7 @@
 import { parseStringToArraySync } from "web-csv-toolbox-wasm";
-import { CSVRecord, CommonOptions } from "./common/types.ts";
+import type { CSVRecord, CommonOptions } from "./common/types.ts";
 import { COMMA, DOUBLE_QUOTE } from "./constants.ts";
-import { type loadWASM } from "./loadWASM.ts";
+import type { loadWASM } from "./loadWASM.ts";
 
 /**
  * Parse CSV string to record of arrays.

--- a/src/parseStringToIterableIterator.ts
+++ b/src/parseStringToIterableIterator.ts
@@ -1,6 +1,6 @@
 import { Lexer } from "./Lexer.ts";
 import { RecordAssembler } from "./RecordAssembler.ts";
-import { CSVRecord, ParseOptions } from "./common/types.ts";
+import type { CSVRecord, ParseOptions } from "./common/types.ts";
 
 export function parseStringToIterableIterator<
   Header extends ReadonlyArray<string>,

--- a/src/parseStringToStream.ts
+++ b/src/parseStringToStream.ts
@@ -1,6 +1,6 @@
 import { Lexer } from "./Lexer.ts";
 import { RecordAssembler } from "./RecordAssembler.ts";
-import { CSVRecord, ParseOptions } from "./common/types.ts";
+import type { CSVRecord, ParseOptions } from "./common/types.ts";
 
 export function parseStringToStream<Header extends ReadonlyArray<string>>(
   csv: string,

--- a/src/parseUint8ArrayStream.ts
+++ b/src/parseUint8ArrayStream.ts
@@ -1,4 +1,4 @@
-import { CSVRecord, ParseBinaryOptions } from "./common/types.ts";
+import type { CSVRecord, ParseBinaryOptions } from "./common/types.ts";
 import { parseStringStream } from "./parseStringStream.ts";
 import { parseUint8ArrayStreamToStream } from "./parseUint8ArrayStreamToStream.ts";
 import { convertStreamToAsyncIterableIterator } from "./utils/convertStreamToAsyncIterableIterator.ts";

--- a/src/parseUint8ArrayStreamToStream.ts
+++ b/src/parseUint8ArrayStreamToStream.ts
@@ -1,6 +1,6 @@
 import { LexerTransformer } from "./LexerTransformer.ts";
 import { RecordAssemblerTransformer } from "./RecordAssemblerTransformer.ts";
-import { CSVRecord, ParseBinaryOptions } from "./common/types.ts";
+import type { CSVRecord, ParseBinaryOptions } from "./common/types.ts";
 import { pipeline } from "./utils/pipeline.ts";
 
 export function parseUint8ArrayStreamToStream<Header extends readonly string[]>(


### PR DESCRIPTION
This pull request updates the import statements in the code to use type imports instead of regular imports. This improves the code's readability and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved type import statements across multiple files to use TypeScript's `type` keyword for type-only imports, enhancing code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->