### PR TITLE
Refactor CSV parsing options and assertions

### DIFF
--- a/.changeset/lazy-geckos-double.md
+++ b/.changeset/lazy-geckos-double.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": minor
+---
+
+Refactor CSV parsing options and assertions

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ A CSV Toolbox utilizing Web Standard APIs.
   - 🧩 Parse CSVs directly from `string`s, `ReadableStream`s, or `Response` objects.
 - ⚙️ **Advanced Parsing Options**: Customize your experience with various delimiters and quotation marks.
   - 🔄 Defaults to `,` and `"` respectively.
-  - 🛠️ Use multi-character/multi-byte delimiters and quotations.
 - 💾 **Specialized Binary CSV Parsing**: Leverage Stream-based processing for versatility and strength.
   - 🔄 Flexible BOM handling.
   - 🗜️ Supports various compression formats.

--- a/README.md
+++ b/README.md
@@ -293,8 +293,7 @@ You can use WebAssembly to parse CSV data for high performance.
 - Parsing with WebAssembly is faster than parsing with JavaScript,
 but it takes time to load the WebAssembly module.
 - Supports only UTF-8 encoding csv data.
-- Demiliter characters are limited to single-byte characters.
-- Quotation characters is only `"`. (Double quotation mark)
+- Quotation characters are only `"`. (Double quotation mark)
   - If you pass a different character, it will throw an error.
 
 ```ts

--- a/src/Lexer.spec.ts
+++ b/src/Lexer.spec.ts
@@ -195,22 +195,6 @@ describe("class Lexer", () => {
           expect(actual).toStrictEqual(expected);
         },
       ),
-      {
-        examples: [
-          [
-            {
-              csv: "QfQQff0Qf0Qf",
-              data: [["Q", "0"]],
-              options: { delimiter: "f0", quotation: "Qf" },
-              expected: [
-                { type: Field, value: "Q" },
-                FieldDelimiter,
-                { type: Field, value: "0" },
-              ],
-            },
-          ],
-        ],
-      },
     );
   });
 

--- a/src/__tests__/helper.ts
+++ b/src/__tests__/helper.ts
@@ -113,8 +113,10 @@ export namespace FC {
     }
     const { excludes = [], ...constraints }: DelimiterConstraints = options;
     return text({
-      minLength: 1,
       ...constraints,
+      minLength: 1,
+      maxLength: 1,
+      kindExcludes: ["string16bits", "unicode"],
     })
       .filter(_excludeFilter([...CRLF]))
       .filter(_excludeFilter(excludes));
@@ -132,6 +134,8 @@ export namespace FC {
     return text({
       ...constraints,
       minLength: 1,
+      maxLength: 1,
+      kindExcludes: ["string16bits", "unicode"],
     })
       .filter(_excludeFilter([...CRLF]))
       .filter(_excludeFilter(excludes));

--- a/src/assertCommonOptions.spec.ts
+++ b/src/assertCommonOptions.spec.ts
@@ -58,4 +58,22 @@ describe("function assertCommonOptions", () => {
       ).toThrow("delimiter must not include CR or LF");
     }
   });
+
+  it("should throw an error if quotation is not a string", () => {
+    expect(() =>
+      assertCommonOptions({
+        quotation: 1 as unknown as string,
+        delimiter: DOUBLE_QUOTE,
+      }),
+    ).toThrow("quotation must be a string");
+  });
+
+  it("should throw an error if delimiter is not a string", () => {
+    expect(() =>
+      assertCommonOptions({
+        quotation: COMMA,
+        delimiter: 1 as unknown as string,
+      }),
+    ).toThrow("delimiter must be a string");
+  });
 });

--- a/src/assertCommonOptions.ts
+++ b/src/assertCommonOptions.ts
@@ -2,29 +2,59 @@ import type { CommonOptions } from "./common/types.ts";
 import { CR, LF } from "./constants.ts";
 
 /**
- * Assert that the options are valid.
- *
- * @param options The options to assert.
+ * Asserts that the provided value is a string and satisfies certain conditions.
+ * @param value - The value to be checked.
+ * @param name - The name of the option.
+ * @throws {Error} If the value is not a string or does not satisfy the conditions.
  */
-export function assertCommonOptions(options: Required<CommonOptions>): void {
-  if (typeof options.quotation === "string" && options.quotation.length === 0) {
-    throw new Error("quotation must not be empty");
+function assertOptionValue(
+  value: string,
+  name: string,
+): asserts value is string {
+  if (typeof value === "string") {
+    switch (true) {
+      case value.length === 0:
+        throw new Error(`${name} must not be empty`);
+      case value.length > 1:
+        throw new Error(`${name} must be a single character`);
+      case value === LF:
+      case value === CR:
+        throw new Error(`${name} must not include CR or LF`);
+      default:
+        break;
+    }
+  } else {
+    throw new Error(`${name} must be a string`);
   }
-  if (typeof options.delimiter === "string" && options.delimiter.length === 0) {
-    throw new Error("delimiter must not be empty");
+}
+
+/**
+ * Asserts that the provided options object contains all the required properties.
+ * Throws an error if any required property is missing
+ * or if the delimiter and quotation length is not 1 byte character,
+ * or if the delimiter is the same as the quotation.
+ *
+ * @example
+ *
+ * ```ts
+ * assertCommonOptions({
+ *   quotation: '"',
+ *   delimiter: ',',
+ * });
+ * ```
+ *
+ * @param options - The options object to be validated.
+ * @throws {Error} If any required property is missing or if the delimiter is the same as the quotation.
+ */
+export function assertCommonOptions(
+  options: Required<CommonOptions>,
+): asserts options is Required<CommonOptions> {
+  for (const [name, value] of Object.entries(options)) {
+    assertOptionValue(value, name);
   }
-  if (options.quotation.includes(LF) || options.quotation.includes(CR)) {
-    throw new Error("quotation must not include CR or LF");
-  }
-  if (options.delimiter.includes(LF) || options.delimiter.includes(CR)) {
-    throw new Error("delimiter must not include CR or LF");
-  }
-  if (
-    options.delimiter.includes(options.quotation) ||
-    options.quotation.includes(options.delimiter)
-  ) {
+  if (options.delimiter === options.quotation) {
     throw new Error(
-      "delimiter and quotation must not include each other as a substring",
+      "delimiter must not be the same as quotation, use different characters",
     );
   }
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -23,19 +23,22 @@ export type Token = FieldToken | typeof FieldDelimiter | typeof RecordDelimiter;
 export interface CommonOptions {
   /**
    * CSV field delimiter.
-   *
-   * @remarks
    * If you want to parse TSV, specify `'\t'`.
    *
-   * This library supports multi-character delimiters.
+   * @remarks
+   * Detail restrictions are as follows:
+   *
+   * - Must not be empty
+   * - Must be a single character
+   *    - Multi-byte characters are not supported
+   * - Must not include CR or LF
+   * - Must not be the same as the quotation
+   *
    * @default ','
    */
   delimiter?: string;
   /**
    * CSV field quotation.
-   *
-   * @remarks
-   * This library supports multi-character quotations.
    *
    * @default '"'
    */


### PR DESCRIPTION
This pull request refactors the CSV parsing options and assertions. It includes changes to the `assertCommonOptions` function to ensure that the provided options are valid. The function now throws an error if any required property is missing, if the delimiter or quotation length is not 1 byte character, or if the delimiter is the same as the quotation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated README to remove mention of unsupported parsing options in CSV Toolbox.
- **Tests**
	- Removed a specific test case example from `Lexer` tests.
	- Enhanced `helper.ts` tests with new constraints on text function inputs.
	- Improved clarity and error handling in `assertCommonOptions` tests.
- **Refactor**
	- Refined validation logic in `assertCommonOptions` to ensure option values meet specific criteria.
	- Updated CSV field delimiter and quotation character specifications in `CommonOptions` interface for clarity and added restrictions.
- **Chores**
	- Made adjustments to import statements and error messages in `assertCommonOptions` for better code organization and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->