### PR TITLE
Update benchmark iterations

### DIFF
--- a/.changeset/strong-colts-help.md
+++ b/.changeset/strong-colts-help.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": patch
+---
+
+Update benchmark iterations

--- a/benchmark/main.ts
+++ b/benchmark/main.ts
@@ -26,7 +26,9 @@ await loadWASM();
 let binaryCSV: Uint8Array = await getAsBinary()
 let stringCSV: string = await getAsString();
 
-const bench = withCodSpeed(new Bench())
+const bench = withCodSpeed(new Bench({
+  iterations: 50,
+}))
   .add('parseString.toArraySync(large-dataset)', () => {
     parseString.toArraySync(stringCSV);
   })


### PR DESCRIPTION
The stability of the benchmark test is unstable, so the number of iterations is increased by a factor of 5 to see what happens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the benchmark iterations in the web CSV toolbox for enhanced performance testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->