### PR TITLE
Change ignoreBOM default value to true

### DIFF
--- a/.changeset/thirty-ladybugs-move.md
+++ b/.changeset/thirty-ladybugs-move.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": minor
+---
+
+Change ignoreBOM default value to true

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ console.log(result);
 | --------------- | ------------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `charset`       | Character encoding for binary CSV inputs          | `utf-8` | See [Encoding API Compatibility](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API/Encodings) for the encoding formats that can be specified. |
 | `decompression` | Decompression algorithm for compressed CSV inputs |         | See [DecompressionStream Compatibility](https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream#browser_compatibilit).                       |
-| `ignoreBOM`     | Whether to ignore Byte Order Mark (BOM)           | `false` | See [TextDecoderOptions.ignoreBOM](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoderStream/ignoreBOM) for more information about the BOM.      |
+| `ignoreBOM`     | Whether to ignore Byte Order Mark (BOM)           | `true`  | See [TextDecoderOptions.ignoreBOM](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoderStream/ignoreBOM) for more information about the BOM.      |
 | `fatal`         | Throw an error on invalid characters              | `false` | See [TextDecoderOptions.fatal](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoderStream/fatal) for more information.                            |
 
 ## How to Contribute 💪

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -79,7 +79,7 @@ export interface BinaryOptions {
    * If you specify true, the BOM will be ignored.
    * If you specify false or not specify it, the BOM will be treated as a normal character.
    * See {@link https://developer.mozilla.org/en-US/docs/Web/API/TextDecoderStream/ignoreBOM | TextDecoderOptions.ignoreBOM} for more information about the BOM.
-   * @default false
+   * @default true In the case of binary, there is no case where the BOM is not be ignored, so the default is treated as true.
    */
   ignoreBOM?: boolean;
   /**

--- a/src/convertBinaryToString.spec.ts
+++ b/src/convertBinaryToString.spec.ts
@@ -5,14 +5,32 @@ describe("function convertBinaryToString", () => {
   it("should convert Uint8Array to string", () => {
     const text = "abc";
     const binary = new TextEncoder().encode(text);
-    const result = convertBinaryToString(binary, {});
+    const result = convertBinaryToString(binary);
     expect(result).toBe(text);
   });
 
   it("should convert ArrayBuffer to string", () => {
     const text = "abc";
     const binary = new TextEncoder().encode(text).buffer;
-    const result = convertBinaryToString(binary, {});
+    const result = convertBinaryToString(binary);
+    expect(result).toBe(text);
+  });
+
+  it("should convert Uint8Array with BOM to string(ignore BOM by default)", () => {
+    const text = "abc";
+    const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
+    const binary = new TextEncoder().encode(text);
+    const result = convertBinaryToString(new Uint8Array([...bom, ...binary]));
+    expect(result).toBe(text);
+  });
+
+  it("should convert ArrayBuffer with BOM to string(ignore BOM by default)", () => {
+    const text = "abc";
+    const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
+    const binary = new TextEncoder().encode(text).buffer;
+    const result = convertBinaryToString(
+      new Uint8Array([...bom, ...new Uint8Array(binary)]),
+    );
     expect(result).toBe(text);
   });
 });

--- a/src/convertBinaryToString.ts
+++ b/src/convertBinaryToString.ts
@@ -2,10 +2,10 @@ import type { ParseBinaryOptions } from "./common/types.ts";
 
 export function convertBinaryToString<Header extends ReadonlyArray<string>>(
   binary: Uint8Array | ArrayBuffer,
-  options: ParseBinaryOptions<Header>,
+  options?: ParseBinaryOptions<Header>,
 ): string {
   return new TextDecoder(options?.charset, {
-    ignoreBOM: options?.ignoreBOM,
+    ignoreBOM: options?.ignoreBOM ?? true,
     fatal: options?.fatal,
   }).decode(binary instanceof ArrayBuffer ? new Uint8Array(binary) : binary);
 }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -146,12 +146,11 @@ export function parse<Header extends ReadonlyArray<string>>(
  * ```ts
  * import { parse } from 'web-csv-toolbox';
  *
- * // This CSV data is gzipped and encoded in shift-jis and has BOM.
+ * // This CSV data is gzipped and encoded in shift-jis.
  * const response = await fetch('https://example.com/data.csv.gz');
  *
  * for await (const record of parse(response, {
  *   charset: 'shift-jis',
- *   ignoreBOM: true,
  *   decomposition: 'gzip',
  * })) {
  *   // ...

--- a/src/parseUint8ArrayStreamToStream.spec.ts
+++ b/src/parseUint8ArrayStreamToStream.spec.ts
@@ -2,13 +2,9 @@ import { expect, test } from "vitest";
 import { parseUint8ArrayStreamToStream } from "./parseUint8ArrayStreamToStream.ts";
 import { SingleValueReadableStream } from "./utils/SingleValueReadableStream.ts";
 
-const csv = new SingleValueReadableStream(
-  new TextEncoder().encode(
-    `name,age
+const CSV_STRING = `name,age
 Alice,42
-Bob,69`,
-  ),
-);
+Bob,69`;
 
 const expected = [
   { name: "Alice", age: "42" },
@@ -17,7 +13,25 @@ const expected = [
 
 test("parseUint8ArrayStreamToStream", async () => {
   let i = 0;
+  const csv = new SingleValueReadableStream(
+    new TextEncoder().encode(CSV_STRING),
+  );
   await parseUint8ArrayStreamToStream(csv).pipeTo(
+    new WritableStream({
+      write(record) {
+        expect(record).toEqual(expected[i++]);
+      },
+    }),
+  );
+});
+
+test("parseUint8ArrayStreamToStream (ignoreBOM by default)", async () => {
+  const csvWithBOM = new SingleValueReadableStream(
+    new Uint8Array([0xef, 0xbb, 0xbf, ...new TextEncoder().encode(CSV_STRING)]),
+  );
+
+  let i = 0;
+  await parseUint8ArrayStreamToStream(csvWithBOM).pipeTo(
     new WritableStream({
       write(record) {
         expect(record).toEqual(expected[i++]);

--- a/src/parseUint8ArrayStreamToStream.ts
+++ b/src/parseUint8ArrayStreamToStream.ts
@@ -7,7 +7,7 @@ export function parseUint8ArrayStreamToStream<Header extends readonly string[]>(
   stream: ReadableStream<Uint8Array>,
   options?: ParseBinaryOptions<Header>,
 ): ReadableStream<CSVRecord<Header>> {
-  const { charset, fatal, ignoreBOM, decomposition } = options ?? {};
+  const { charset, fatal, ignoreBOM = true, decomposition } = options ?? {};
   return decomposition
     ? pipeline(
         stream,


### PR DESCRIPTION
This pull request updates the default value of the `ignoreBOM` option to `true` in the `convertBinaryToString` function. Previously, the default value was `false`.

The `ignoreBOM` option determines whether to ignore the Byte Order Mark (BOM) when converting binary data to a string.

This change ensures that the BOM is ignored by default, providing more consistent behavior.