### PR TITLE
Disable macos FireFox browser testing on CI

### DIFF
--- a/.changeset/swift-yaks-repeat.md
+++ b/.changeset/swift-yaks-repeat.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": patch
+---
+
+Disable macos FireFox browser testing on CI

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -207,8 +207,9 @@ jobs:
       matrix:
         browsers:
           - chrome
-          - firefox
-          # Headless Safari is currentry not supported
+          # TODO: Consider alternatives to frequent rate limit restrictions.
+          # - firefox
+          # NOTE: Headless Safari is currentry not supported
           # https://github.com/vitest-dev/vitest/blob/main/packages/browser/src/node/providers/webdriver.ts#L39-L41
           # - safari
     steps:


### PR DESCRIPTION
This pull request disables the FireFox browser testing on CI for macOS. This change is made to address frequent rate limit restrictions and improve the overall testing process.