### PR TITLE
Add test on Node.js 22

### DIFF
--- a/.changeset/soft-ghosts-swim.md
+++ b/.changeset/soft-ghosts-swim.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": patch
+---
+
+Add test on Node.js 22

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,7 +140,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6


### PR DESCRIPTION
This pull request adds a new test for Node.js 22 to the existing test suite. This ensures that the code is compatible with the latest version of Node.js.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added testing support for Node.js version 22 in the CI workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->