### PR TITLE
Remove unused code for checking delimiter repetition in escapeField

### DIFF
--- a/src/escapeField.ts
+++ b/src/escapeField.ts
@@ -8,20 +8,6 @@ export interface EscapeFieldOptions extends CommonOptions {
 }
 
 const REPLACED_PATTERN_CACHE = new Map<string, string>();
-const CHECK_CACHE = new Map<string, (v: string) => boolean>();
-
-/**
- * Check function for special case of delimiter is repetition of one type of character.
- *
- * Check if the value starts or ends with the delimiter character.
- *
- * @param delimiter which is assumed to be a single character.
- */
-function specialCheckFordelimiterIsRepetitionOfOneTypeOfCharacter(
-  delimiter: string,
-): (v: string) => boolean {
-  return (v: string) => v.startsWith(delimiter) || v.endsWith(delimiter);
-}
 
 /**
  * Escape the field.
@@ -48,19 +34,6 @@ export function escapeField(
     );
   }
   const replacedPattern = REPLACED_PATTERN_CACHE.get(quotation)!;
-  let check: (v: string) => boolean;
-  if (CHECK_CACHE.has(delimiter)) {
-    check = CHECK_CACHE.get(delimiter)!;
-  } else {
-    const a = new Set([...delimiter]);
-    if (delimiter.length > 1 && a.size === 1) {
-      const [d] = [...a];
-      check = specialCheckFordelimiterIsRepetitionOfOneTypeOfCharacter(d);
-    } else {
-      check = () => false;
-    }
-    CHECK_CACHE.set(delimiter, check);
-  }
 
   const contents = value.replaceAll(quotation, replacedPattern);
 
@@ -77,8 +50,7 @@ export function escapeField(
     occurrences(wrappedContents, delimiter) >= 3 ||
     // If wrapped contents has more than 1 quotation,
     // it should be quoted.
-    occurrences(wrappedContents, quotation) >= 1 ||
-    check(contents)
+    occurrences(wrappedContents, quotation) >= 1
   ) {
     return quotation + contents + quotation;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the delimiter checking logic in the `escapeField` function for improved performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->