### PR TITLE
Support AbortSignal / AbortController

### DIFF
--- a/.changeset/thirty-plants-raise.md
+++ b/.changeset/thirty-plants-raise.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": minor
+---
+
+Support AbortSignal

--- a/README.md
+++ b/README.md
@@ -49,21 +49,21 @@ A CSV Toolbox utilizing Web Standard APIs.
 
 - 🌊 **Efficient CSV Parsing with Streams**
   - 💻 Leveraging the [WHATWG Streams API](https://streams.spec.whatwg.org/) and other Web APIs for seamless and efficient data processing.
+- 🛑 **AbortSignal and Timeout Support**: Ensure your CSV processing is cancellable, including support for automatic timeouts.
+  - ✋ Integrate with [`AbortController`](https://developer.mozilla.org/docs/Web/API/AbortController) to manually cancel operations as needed.
+  - ⏳ Use [`AbortSignal.timeout`](https://developer.mozilla.org/docs/Web/API/AbortSignal/timeout_static) to automatically cancel operations that exceed a specified time limit.
 - 🎨 **Flexible Source Support**
   - 🧩 Parse CSVs directly from `string`s, `ReadableStream`s, or `Response` objects.
 - ⚙️ **Advanced Parsing Options**: Customize your experience with various delimiters and quotation marks.
   - 🔄 Defaults to `,` and `"` respectively.
-- 🛑 **AbortSignal and Timeout Support**: Ensure your CSV processing is cancellable, including support for automatic timeouts.
-  - ✋ Integrate with [`AbortController`](https://developer.mozilla.org/docs/Web/API/AbortController) to manually cancel operations as needed.
-  - ⏳ Use [`AbortSignal.timeout`](https://developer.mozilla.org/docs/Web/API/AbortSignal/timeout_static) to automatically cancel operations that exceed a specified time limit.
 - 💾 **Specialized Binary CSV Parsing**: Leverage Stream-based processing for versatility and strength.
   - 🔄 Flexible BOM handling.
   - 🗜️ Supports various compression formats.
   - 🔤 Charset specification for diverse encoding.
-- 📦 **Lightweight and Zero Dependencies**: No external dependencies, only Web Standards APIs.
-- 📚 **Fully Typed and Documented**: Fully typed and documented with [TypeDoc](https://typedoc.org/).
 - 🚀 **Using WebAssembly for High Performance**: WebAssembly is used for high performance parsing. (_Experimental_)
   - 📦 WebAssembly is used for high performance parsing.
+- 📦 **Lightweight and Zero Dependencies**: No external dependencies, only Web Standards APIs.
+- 📚 **Fully Typed and Documented**: Fully typed and documented with [TypeDoc](https://typedoc.org/).
 
 ## Installation 📥
 

--- a/src/Lexer.test.ts
+++ b/src/Lexer.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { assert, beforeEach, describe, expect, test } from "vitest";
 import { Lexer } from "./Lexer";
 import { Field, FieldDelimiter, RecordDelimiter } from "./common/constants";
 
@@ -253,16 +253,13 @@ describe("Lexer", () => {
 
     test("should thorw DOMException named AbortError if the signal is aborted", () => {
       controller.abort();
-
-      expect(() => [...lexer.lex('"Hello"')]).toThrow(DOMException);
-
-      expect(() => [
-        ...lexer.lex('"Hello"'),
-      ]).toThrowErrorMatchingInlineSnapshot(
-        // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-        `[AbortError: This operation was aborted]`,
-      );
-      //
+      try {
+        [...lexer.lex('"Hello"')];
+        expect.unreachable();
+      } catch (error) {
+        assert(error instanceof DOMException);
+        expect(error.name).toBe("AbortError");
+      }
     });
 
     test("should throw custom error if the signal is aborted with custom reason", () => {

--- a/src/Lexer.test.ts
+++ b/src/Lexer.test.ts
@@ -280,4 +280,25 @@ describe("Lexer", () => {
       );
     });
   });
+
+  test("should throw DOMException named TimeoutError if the signal is aborted with timeout", async () => {
+    function waitAbort(signal: AbortSignal) {
+      return new Promise<void>((resolve) => {
+        signal.addEventListener("abort", () => {
+          resolve();
+        });
+      });
+    }
+    const signal = AbortSignal.timeout(0);
+    await waitAbort(signal);
+
+    lexer = new Lexer({ signal });
+    try {
+      [...lexer.lex('"Hello"')];
+      expect.unreachable();
+    } catch (error) {
+      assert(error instanceof DOMException);
+      expect(error.name).toBe("TimeoutError");
+    }
+  });
 });

--- a/src/RecordAssembler.test.ts
+++ b/src/RecordAssembler.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { RecordAssembler } from "./RecordAssembler.js";
+import { Field } from "./common/constants";
+
+describe("RecordAssembler", () => {
+  describe("when AbortSignal is provided", () => {
+    let assembler: RecordAssembler<readonly string[]>;
+    let controller: AbortController;
+
+    beforeEach(() => {
+      controller = new AbortController();
+      assembler = new RecordAssembler({
+        signal: controller.signal,
+      });
+    });
+    test("should throw DOMException named AbortError if the signal is aborted", () => {
+      controller.abort();
+
+      expect(() => [
+        ...assembler.assemble([
+          {
+            type: Field,
+            value: "",
+            location: {
+              start: { line: 1, column: 1, offset: 0 },
+              end: { line: 1, column: 1, offset: 0 },
+              rowNumber: 1,
+            },
+          },
+        ]),
+      ]).toThrow(DOMException);
+
+      expect(() => [
+        ...assembler.assemble([
+          {
+            type: Field,
+            value: "",
+            location: {
+              start: { line: 1, column: 1, offset: 0 },
+              end: { line: 1, column: 1, offset: 0 },
+              rowNumber: 1,
+            },
+          },
+        ]),
+      ]).toThrowErrorMatchingInlineSnapshot(
+        // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
+        `[AbortError: This operation was aborted]`,
+      );
+    });
+
+    test("should throw custom error if the signal is aborted with custom reason", () => {
+      class MyCustomError extends Error {
+        constructor(message: string) {
+          super(message);
+          this.name = "MyCustomError";
+        }
+      }
+
+      controller.abort(new MyCustomError("Custom reason"));
+
+      expect(() => {
+        [
+          ...assembler.assemble([
+            {
+              type: Field,
+              value: "",
+              location: {
+                start: { line: 1, column: 1, offset: 0 },
+                end: { line: 1, column: 1, offset: 0 },
+                rowNumber: 1,
+              },
+            },
+          ]),
+        ];
+      }).toThrowErrorMatchingInlineSnapshot(
+        // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
+        `[MyCustomError: Custom reason]`,
+      );
+    });
+  });
+});

--- a/src/RecordAssembler.test.ts
+++ b/src/RecordAssembler.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { assert, beforeEach, describe, expect, test } from "vitest";
 import { RecordAssembler } from "./RecordAssembler.js";
 import { Field } from "./common/constants";
 
@@ -15,37 +15,25 @@ describe("RecordAssembler", () => {
     });
     test("should throw DOMException named AbortError if the signal is aborted", () => {
       controller.abort();
-
-      expect(() => [
-        ...assembler.assemble([
-          {
-            type: Field,
-            value: "",
-            location: {
-              start: { line: 1, column: 1, offset: 0 },
-              end: { line: 1, column: 1, offset: 0 },
-              rowNumber: 1,
+      try {
+        [
+          ...assembler.assemble([
+            {
+              type: Field,
+              value: "",
+              location: {
+                start: { line: 1, column: 1, offset: 0 },
+                end: { line: 1, column: 1, offset: 0 },
+                rowNumber: 1,
+              },
             },
-          },
-        ]),
-      ]).toThrow(DOMException);
-
-      expect(() => [
-        ...assembler.assemble([
-          {
-            type: Field,
-            value: "",
-            location: {
-              start: { line: 1, column: 1, offset: 0 },
-              end: { line: 1, column: 1, offset: 0 },
-              rowNumber: 1,
-            },
-          },
-        ]),
-      ]).toThrowErrorMatchingInlineSnapshot(
-        // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-        `[AbortError: This operation was aborted]`,
-      );
+          ]),
+        ];
+        expect.unreachable();
+      } catch (error) {
+        assert(error instanceof DOMException);
+        expect(error.name).toBe("AbortError");
+      }
     });
 
     test("should throw custom error if the signal is aborted with custom reason", () => {

--- a/src/RecordAssembler.test.ts
+++ b/src/RecordAssembler.test.ts
@@ -66,4 +66,36 @@ describe("RecordAssembler", () => {
       );
     });
   });
+
+  test("should throw DOMException named TimeoutError if the signal is aborted with timeout", async () => {
+    function waitAbort(signal: AbortSignal) {
+      return new Promise<void>((resolve) => {
+        signal.addEventListener("abort", () => {
+          resolve();
+        });
+      });
+    }
+    const signal = AbortSignal.timeout(0);
+    await waitAbort(signal);
+    const assembler = new RecordAssembler({ signal });
+    try {
+      [
+        ...assembler.assemble([
+          {
+            type: Field,
+            value: "",
+            location: {
+              start: { line: 1, column: 1, offset: 0 },
+              end: { line: 1, column: 1, offset: 0 },
+              rowNumber: 1,
+            },
+          },
+        ]),
+      ];
+      expect.unreachable();
+    } catch (error) {
+      assert(error instanceof DOMException);
+      expect(error.name).toBe("TimeoutError");
+    }
+  });
 });

--- a/src/RecordAssembler.ts
+++ b/src/RecordAssembler.ts
@@ -11,10 +11,14 @@ export class RecordAssembler<Header extends ReadonlyArray<string>> {
   #row: string[] = [];
   #header: Header | undefined;
   #dirty = false;
+  #signal?: AbortSignal;
 
   constructor(options: RecordAssemblerOptions<Header> = {}) {
     if (options.header !== undefined && Array.isArray(options.header)) {
       this.#setHeader(options.header);
+    }
+    if (options.signal) {
+      this.#signal = options.signal;
     }
   }
 
@@ -23,6 +27,7 @@ export class RecordAssembler<Header extends ReadonlyArray<string>> {
     flush = true,
   ): IterableIterator<CSVRecord<Header>> {
     for (const token of tokens) {
+      this.#signal?.throwIfAborted();
       switch (token.type) {
         case FieldDelimiter:
           this.#fieldIndex++;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -82,6 +82,15 @@ export interface RecordDelimiterToken {
 export type Token = FieldToken | FieldDelimiterToken | RecordDelimiterToken;
 
 /**
+ * AbortSignal Options.
+ *
+ * @category Types
+ */
+export interface AbortSignalOptions {
+  signal?: AbortSignal;
+}
+
+/**
  * CSV Common Options.
  * @category Types
  */
@@ -197,7 +206,8 @@ export interface RecordAssemblerOptions<Header extends ReadonlyArray<string>> {
  */
 export interface ParseOptions<Header extends ReadonlyArray<string>>
   extends CommonOptions,
-    RecordAssemblerOptions<Header> {}
+    RecordAssemblerOptions<Header>,
+    AbortSignalOptions {}
 
 /**
  * Parse options for CSV binary.

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -184,7 +184,8 @@ export interface BinaryOptions {
  * If you don't specify `header`,
  * the first record will be treated as a header.
  */
-export interface RecordAssemblerOptions<Header extends ReadonlyArray<string>> {
+export interface RecordAssemblerOptions<Header extends ReadonlyArray<string>>
+  extends AbortSignalOptions {
   /**
    * CSV header.
    *

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -87,6 +87,50 @@ export type Token = FieldToken | FieldDelimiterToken | RecordDelimiterToken;
  * @category Types
  */
 export interface AbortSignalOptions {
+  /**
+   * The signal to abort the operation.
+   *
+   * @remarks
+   *
+   * If the signal is aborted, the operation will be stopped.
+   *
+   * @example Abort with user action
+   *
+   * ```ts
+   * const controller = new AbortController();
+   *
+   * const csv = "foo,bar\n1,2\n3,4";
+   * try {
+   *   const result = await parse(csv, { signal: controller.signal });
+   * } catch (e) {
+   *   if (e instanceof DOMException && e.name === "AbortError") {
+   *     console.log("Aborted");
+   *   }
+   * }
+   *
+   * // Abort with user action
+   * document.getElementById("cancel-button")
+   *  .addEventListener("click", () => {
+   *    controller.abort();
+   *   });
+   * ```
+   *
+   * @example Abort with timeout
+   *
+   * ```ts
+   * const csv = "foo,bar\n1,2\n3,4";
+   *
+   * try {
+   *   const result = await parse(csv, { signal: AbortSignal.timeout(1000) });
+   * } catch (e) {
+   *   if (e instanceof DOMException && e.name === "TimeoutError") {
+   *     console.log("Timeout");
+   *   }
+   * }
+   * ```
+   *
+   * @default undefined
+   */
   signal?: AbortSignal;
 }
 


### PR DESCRIPTION
This pull request adds support for handling signal aborts during lexing and record assembling operations. It introduces the `AbortSignalOptions` interface and modifies the `Lexer` and `RecordAssembler` classes to accept an optional `signal` parameter. When the signal is aborted, the operations will throw a `DOMException` named `AbortError`. Additionally, custom errors can be thrown with a custom reason. This enhancement improves the robustness and error handling capabilities of the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added support for cancelling asynchronous operations in the CSV Toolbox using `AbortSignal`, enhancing user experience and resource management.
	- Introduced new parameters in CSV parsing functions allowing users to specify an `AbortSignal` for long-running tasks.
	- Updated documentation with examples on how to implement and utilize cancellation features effectively.

- **Bug Fixes**
	- Enhanced error handling in the Lexer and RecordAssembler for scenarios when operations are aborted, ensuring proper exceptions are thrown.

- **Documentation**
	- Added detailed instructions on using `AbortSignal` and `AbortController` in the CSV Toolbox documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->