### PR TITLE
Remove unnecessary processes for convertIterableIteratorToAsync function

### DIFF
--- a/.changeset/gorgeous-seals-worry.md
+++ b/.changeset/gorgeous-seals-worry.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": patch
+---
+
+Remove unnecessary processes for convertIterableIteratorToAsync function

--- a/src/utils/convertIterableIteratorToAsync.ts
+++ b/src/utils/convertIterableIteratorToAsync.ts
@@ -3,8 +3,7 @@ export function convertIterableIteratorToAsync<T>(
 ): AsyncIterableIterator<T> {
   return {
     async next() {
-      const result = iterator.next();
-      return Promise.resolve(result);
+      return iterator.next();
     },
     [Symbol.asyncIterator]() {
       return this;


### PR DESCRIPTION
This pull request removes unnecessary processes for the convertIterableIteratorToAsync function. The function now directly returns the result of the iterator's next() method, eliminating the need for an extra Promise.resolve() call. This improves the efficiency and readability of the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the performance of the iterable iterator conversion process in the web-csv-toolbox module.
	
- **Bug Fixes**
	- Modified the behavior of the `next` method to return results directly, improving handling of iterator outputs.
	
- **Chores**
	- Streamlined the internal logic of the conversion function for better maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->