### PR TITLE
Remove InvalidOptionError class

### DIFF
--- a/.changeset/sixty-moons-explain.md
+++ b/.changeset/sixty-moons-explain.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": minor
+---
+
+Remove InvalidOptionError class

--- a/src/LexerTransformer.test.ts
+++ b/src/LexerTransformer.test.ts
@@ -25,7 +25,7 @@ describe("LexerTransformer", () => {
         }),
     ).toThrowErrorMatchingInlineSnapshot(
       // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-      `[InvalidOptionError: delimiter must not be empty]`,
+      `[RangeError: delimiter must not be empty]`,
     );
 
     expect(
@@ -35,7 +35,7 @@ describe("LexerTransformer", () => {
         }),
     ).toThrowErrorMatchingInlineSnapshot(
       // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-      `[InvalidOptionError: quotation must not be empty]`,
+      `[RangeError: quotation must not be empty]`,
     );
   });
 

--- a/src/assertCommonOptions.spec.ts
+++ b/src/assertCommonOptions.spec.ts
@@ -13,7 +13,7 @@ describe("function assertCommonOptions", () => {
       }),
     ).toThrowErrorMatchingInlineSnapshot(
       // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-      `[InvalidOptionError: quotation must not be empty]`,
+      `[RangeError: quotation must not be empty]`,
     );
   });
 
@@ -25,7 +25,7 @@ describe("function assertCommonOptions", () => {
       }),
     ).toThrowErrorMatchingInlineSnapshot(
       // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-      `[InvalidOptionError: delimiter must not be empty]`,
+      `[RangeError: delimiter must not be empty]`,
     );
   });
 
@@ -40,7 +40,7 @@ describe("function assertCommonOptions", () => {
             assertCommonOptions({ quotation: value, delimiter: value }),
           ).toThrowErrorMatchingInlineSnapshot(
             // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-            `[InvalidOptionError: delimiter must not be the same as quotation, use different characters]`,
+            `[RangeError: delimiter must not be the same as quotation, use different characters]`,
           );
         },
       ),
@@ -56,7 +56,7 @@ describe("function assertCommonOptions", () => {
         }),
       ).toThrowErrorMatchingInlineSnapshot(
         // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-        `[InvalidOptionError: quotation must not include CR or LF]`,
+        `[RangeError: quotation must not include CR or LF]`,
       );
     }
     for (const delimiter of [CR, LF]) {
@@ -67,7 +67,7 @@ describe("function assertCommonOptions", () => {
         }),
       ).toThrowErrorMatchingInlineSnapshot(
         // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-        `[InvalidOptionError: delimiter must not include CR or LF]`,
+        `[RangeError: delimiter must not include CR or LF]`,
       );
     }
   });

--- a/src/assertCommonOptions.ts
+++ b/src/assertCommonOptions.ts
@@ -1,4 +1,3 @@
-import { InvalidOptionError } from "./common/errors.ts";
 import type { CommonOptions } from "./common/types.ts";
 import { CR, LF } from "./constants.ts";
 
@@ -6,7 +5,7 @@ import { CR, LF } from "./constants.ts";
  * Asserts that the provided value is a string and satisfies certain conditions.
  * @param value - The value to be checked.
  * @param name - The name of the option.
- * @throws {InvalidOptionError} If the value is empty, longer than 1 byte, or includes CR or LF.
+ * @throws {RangeError} If the value is empty, longer than 1 byte, or includes CR or LF.
  * @throws {TypeError} If the value is not a string.
  */
 function assertOptionValue(
@@ -16,12 +15,12 @@ function assertOptionValue(
   if (typeof value === "string") {
     switch (true) {
       case value.length === 0:
-        throw new InvalidOptionError(`${name} must not be empty`);
+        throw new RangeError(`${name} must not be empty`);
       case value.length > 1:
-        throw new InvalidOptionError(`${name} must be a single character`);
+        throw new RangeError(`${name} must be a single character`);
       case value === LF:
       case value === CR:
-        throw new InvalidOptionError(`${name} must not include CR or LF`);
+        throw new RangeError(`${name} must not include CR or LF`);
       default:
         break;
     }
@@ -46,7 +45,7 @@ function assertOptionValue(
  * ```
  *
  * @param options - The options object to be validated.
- * @throws {InvalidOptionError} If any required property is missing or if the delimiter is the same as the quotation.
+ * @throws {RangeError} If any required property is missing or if the delimiter is the same as the quotation.
  * @throws {TypeError} If any required property is not a string.
  */
 export function assertCommonOptions(
@@ -56,7 +55,7 @@ export function assertCommonOptions(
     assertOptionValue(options[name], name);
   }
   if (options.delimiter === options.quotation) {
-    throw new InvalidOptionError(
+    throw new RangeError(
       "delimiter must not be the same as quotation, use different characters",
     );
   }

--- a/src/common/errors.spec.ts
+++ b/src/common/errors.spec.ts
@@ -1,40 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { InvalidOptionError, ParseError } from "./errors";
-
-describe("InvalidOptionError", () => {
-  it("should be an instance of Error", () => {
-    // The InvalidOptionError class should be an instance of Error.
-    expect(new InvalidOptionError()).toBeInstanceOf(Error);
-  });
-
-  it("should have a name property", () => {
-    // The InvalidOptionError class should have
-    // a name property equal to "InvalidOptionError".
-    expect(new InvalidOptionError().name).toStrictEqual("InvalidOptionError");
-  });
-
-  it("should have a message property", () => {
-    // The InvalidOptionError class should have
-    // a message property equal to empty string.
-    expect(new InvalidOptionError().message).toStrictEqual("");
-
-    // The InvalidOptionError class should have
-    // a message property equal to the provided value.
-    expect(new InvalidOptionError("message").message).toStrictEqual("message");
-  });
-
-  it("should have a cause property", () => {
-    // The InvalidOptionError class should have
-    // a cause property equal to undefined.
-    expect(new InvalidOptionError().cause).toBeUndefined();
-
-    // The InvalidOptionError class should have
-    // a cause property equal to the provided value.
-    expect(
-      new InvalidOptionError("", { cause: new Error() }).cause,
-    ).toStrictEqual(new Error());
-  });
-});
+import { ParseError } from "./errors";
 
 describe("ParseError", () => {
   it("should be an instance of Error", () => {

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -1,16 +1,6 @@
 import type { Position } from "./types.js";
 
 /**
- * Error class for invalid option errors.
- */
-export class InvalidOptionError extends Error {
-  constructor(message?: string, options?: ErrorOptions) {
-    super(message, options);
-    this.name = "InvalidOptionError";
-  }
-}
-
-/**
  * Options for creating a parse error.
  */
 export interface ParseErrorOptions extends ErrorOptions {

--- a/src/commonParseErrorHandling.spec.ts
+++ b/src/commonParseErrorHandling.spec.ts
@@ -1,22 +1,23 @@
 import { describe, expect, it } from "vitest";
-import { InvalidOptionError, ParseError } from "./common/errors";
+import { ParseError } from "./common/errors";
 import { commonParseErrorHandling } from "./commonParseErrorHandling";
 
 describe("function commonParseErrorHandling", () => {
   it("should throws ParseError for ParseError instance", () => {
-    const parseError = new ParseError(
+    const error = new ParseError(
       "An error occurred while parsing the CSV data.",
     );
-    expect(() => commonParseErrorHandling(parseError)).toThrowError(parseError);
+    expect(() => commonParseErrorHandling(error)).toThrowError(error);
   });
 
-  it("should throws InvalidOptionError for InvalidOptionError instance", () => {
-    const invalidOptionError = new InvalidOptionError(
-      "Invalid option provided.",
-    );
-    expect(() => commonParseErrorHandling(invalidOptionError)).toThrowError(
-      invalidOptionError,
-    );
+  it("should throws RangeError for RangeError instance", () => {
+    const error = new RangeError("Invalid option provided.");
+    expect(() => commonParseErrorHandling(error)).toThrowError(error);
+  });
+
+  it("should throws TypeError for TypeError instance", () => {
+    const error = new TypeError("Invalid option provided.");
+    expect(() => commonParseErrorHandling(error)).toThrowError(error);
   });
 
   it("should throws ParseError for unknown error", () => {

--- a/src/commonParseErrorHandling.ts
+++ b/src/commonParseErrorHandling.ts
@@ -1,15 +1,20 @@
-import { InvalidOptionError, ParseError } from "./common/errors";
+import { ParseError } from "./common/errors";
 
 /**
  * Common error handling for parsing CSV data.
  *
  * @param error - The error to handle.
  * @throws {ParseError} When an error occurs while parsing the CSV data.
- * @throws {InvalidOptionError} When an invalid option is provided.
+ * @throws {RangeError} When an invalid option is provided.
+ * @throws {TypeError} When an invalid option is provided.
  */
 
 export function commonParseErrorHandling(error: unknown): never {
-  if (error instanceof ParseError || error instanceof InvalidOptionError) {
+  if (
+    error instanceof ParseError ||
+    error instanceof RangeError ||
+    error instanceof TypeError
+  ) {
     throw error;
   }
   throw new ParseError("An error occurred while parsing the CSV data.", {

--- a/src/parseBinaryToArraySync.test.ts
+++ b/src/parseBinaryToArraySync.test.ts
@@ -21,6 +21,6 @@ test("throws an error if the binary is invalid", () => {
     }),
   ).toThrowErrorMatchingInlineSnapshot(
     // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-    `[ParseError: An error occurred while parsing the CSV data.]`,
+    `[TypeError: The encoded data was not valid for encoding utf-8]`,
   );
 });

--- a/src/parseBinaryToArraySync.test.ts
+++ b/src/parseBinaryToArraySync.test.ts
@@ -19,8 +19,5 @@ test("throws an error if the binary is invalid", () => {
     parseBinaryToArraySync(new Uint8Array([0x80]), {
       fatal: true,
     }),
-  ).toThrowErrorMatchingInlineSnapshot(
-    // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-    `[TypeError: The encoded data was not valid for encoding utf-8]`,
-  );
+  ).toThrowError(TypeError); // NOTE: Error messages vary depending on the execution environment.
 });

--- a/src/parseBinaryToIterableIterator.spec.ts
+++ b/src/parseBinaryToIterableIterator.spec.ts
@@ -22,8 +22,5 @@ test("throws an error if the binary is invalid", () => {
     parseBinaryToIterableIterator(new Uint8Array([0x80]), {
       fatal: true,
     }),
-  ).toThrowErrorMatchingInlineSnapshot(
-    // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-    `[TypeError: The encoded data was not valid for encoding utf-8]`,
-  );
+  ).toThrowError(TypeError); // NOTE: Error messages vary depending on the execution environment.
 });

--- a/src/parseBinaryToIterableIterator.spec.ts
+++ b/src/parseBinaryToIterableIterator.spec.ts
@@ -24,6 +24,6 @@ test("throws an error if the binary is invalid", () => {
     }),
   ).toThrowErrorMatchingInlineSnapshot(
     // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-    `[ParseError: An error occurred while parsing the CSV data.]`,
+    `[TypeError: The encoded data was not valid for encoding utf-8]`,
   );
 });

--- a/src/parseBinaryToStream.spec.ts
+++ b/src/parseBinaryToStream.spec.ts
@@ -26,8 +26,5 @@ test("throws an error if the binary is invalid", () => {
     parseBinaryToStream(new Uint8Array([0x80]), {
       fatal: true,
     }),
-  ).toThrowErrorMatchingInlineSnapshot(
-    // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-    `[TypeError: The encoded data was not valid for encoding utf-8]`,
-  );
+  ).toThrowError(TypeError); // NOTE: Error messages vary depending on the execution environment.
 });

--- a/src/parseBinaryToStream.spec.ts
+++ b/src/parseBinaryToStream.spec.ts
@@ -28,6 +28,6 @@ test("throws an error if the binary is invalid", () => {
     }),
   ).toThrowErrorMatchingInlineSnapshot(
     // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-    `[ParseError: An error occurred while parsing the CSV data.]`,
+    `[TypeError: The encoded data was not valid for encoding utf-8]`,
   );
 });

--- a/src/parseResponse.spec.ts
+++ b/src/parseResponse.spec.ts
@@ -14,7 +14,7 @@ describe("parseRequest function", () => {
     });
     expect(() => parseResponse(response)).toThrowErrorMatchingInlineSnapshot(
       // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-      `[ParseError: An error occurred while parsing the CSV data.]`,
+      `[RangeError: Invalid mime type: "application/json"]`,
     );
   });
   it("should throw error if request body is null", async () => {
@@ -25,7 +25,7 @@ describe("parseRequest function", () => {
     });
     expect(() => parseResponse(response)).toThrowErrorMatchingInlineSnapshot(
       // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-      `[ParseError: An error occurred while parsing the CSV data.]`,
+      `[RangeError: Response body is null]`,
     );
   });
 

--- a/src/parseResponseToStream.spec.ts
+++ b/src/parseResponseToStream.spec.ts
@@ -28,7 +28,7 @@ describe("parseResponseToStream", () => {
       parseResponseToStream(response),
     ).toThrowErrorMatchingInlineSnapshot(
       // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-      `[ParseError: An error occurred while parsing the CSV data.]`,
+      `[RangeError: Invalid mime type: "application/json"]`,
     );
   });
 
@@ -42,7 +42,7 @@ describe("parseResponseToStream", () => {
       parseResponseToStream(response),
     ).toThrowErrorMatchingInlineSnapshot(
       // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-      `[ParseError: An error occurred while parsing the CSV data.]`,
+      `[RangeError: Response body is null]`,
     );
   });
 

--- a/src/parseString.spec.ts
+++ b/src/parseString.spec.ts
@@ -60,7 +60,7 @@ describe("parseString function", () => {
       }
     }).rejects.toThrowErrorMatchingInlineSnapshot(
       // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-      `[InvalidOptionError: delimiter must not be empty]`,
+      `[RangeError: delimiter must not be empty]`,
     );
   });
 });

--- a/src/parseStringToArraySyncWASM.spec.ts
+++ b/src/parseStringToArraySyncWASM.spec.ts
@@ -64,7 +64,7 @@ describe("parseStringToArraySyncWASM", async () => {
       parseStringToArraySyncWASM(csv, { delimiter: "ab" }),
     ).toThrowErrorMatchingInlineSnapshot(
       // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-      `[InvalidOptionError: Invalid delimiter, must be a single character on WASM.]`,
+      `[RangeError: Invalid delimiter, must be a single character on WASM.]`,
     );
   });
 
@@ -75,7 +75,7 @@ describe("parseStringToArraySyncWASM", async () => {
       parseStringToArraySyncWASM(csv, { quotation: "'" }),
     ).toThrowErrorMatchingInlineSnapshot(
       // biome-ignore lint/style/noUnusedTemplateLiteral: This is a snapshot
-      `[InvalidOptionError: Invalid quotation, must be double quote on WASM.]`,
+      `[RangeError: Invalid quotation, must be double quote on WASM.]`,
     );
   });
 });

--- a/src/parseStringToArraySyncWASM.ts
+++ b/src/parseStringToArraySyncWASM.ts
@@ -1,6 +1,5 @@
 import { parseStringToArraySync } from "web-csv-toolbox-wasm";
 import { assertCommonOptions } from "./assertCommonOptions.ts";
-import { InvalidOptionError } from "./common/errors.ts";
 import type { CSVRecord, CommonOptions } from "./common/types.ts";
 import { COMMA, DOUBLE_QUOTE } from "./constants.ts";
 import type { loadWASM } from "./loadWASM.ts";
@@ -39,6 +38,7 @@ import type { loadWASM } from "./loadWASM.ts";
  * // [{ a: "1", b: "2", c: "3" }]
  * ```
  * @beta
+ * @throws {RangeError | TypeError} - If provided options are invalid.
  */
 export function parseStringToArraySyncWASM<Header extends readonly string[]>(
   csv: string,
@@ -46,14 +46,12 @@ export function parseStringToArraySyncWASM<Header extends readonly string[]>(
 ): CSVRecord<Header>[] {
   const { delimiter = COMMA, quotation = DOUBLE_QUOTE } = options;
   if (typeof delimiter !== "string" || delimiter.length !== 1) {
-    throw new InvalidOptionError(
+    throw new RangeError(
       "Invalid delimiter, must be a single character on WASM.",
     );
   }
   if (quotation !== DOUBLE_QUOTE) {
-    throw new InvalidOptionError(
-      "Invalid quotation, must be double quote on WASM.",
-    );
+    throw new RangeError("Invalid quotation, must be double quote on WASM.");
   }
   assertCommonOptions({ delimiter, quotation });
   const demiliterCode = delimiter.charCodeAt(0);


### PR DESCRIPTION
Custom error classes without additional information in JavaScript add redundancy to the project.

Since the custom error class was originally defined for the use case of expressing optional irregularities, RangeError, a standard JavaScript error class, is used.

In addition, when CSV is handled as binary, the `InvalidOptionError` exception is raised when `fatal: true` is specified as an option, but TypeError is raised as the standard specification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling by removing `InvalidOptionError` and replacing it with standard JavaScript error types (`RangeError`, `TypeError`) across several functions.
- **Documentation**
	- Updated documentation to reflect recent changes in error handling, ensuring clarity on expected error types in various functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->