### PR TITLE
Update concurrency configuration in main Workflow

### DIFF
--- a/.changeset/purple-chicken-reply.md
+++ b/.changeset/purple-chicken-reply.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": patch
+---
+
+Update concurrency configuration in main Workflow

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,9 @@ on:
       - main
   pull_request:
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
 


### PR DESCRIPTION
This pull request updates the concurrency configuration in the main.yaml file. The `concurrency` field is modified to include a `group` property with the value of `${{ github.workflow }}-${{ github.ref }}` and a `cancel-in-progress` property set to true. This change ensures that any in-progress jobs with the same workflow and reference are canceled when a new job is triggered.