### PR TITLE
Use fast-check instead of @fast-check/vitest in test files

### DIFF
--- a/.changeset/shy-otters-flow.md
+++ b/.changeset/shy-otters-flow.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": patch
+---
+
+Use fast-check instead of @fast-check/vitest in test files

--- a/config/vitest.setup.ts
+++ b/config/vitest.setup.ts
@@ -1,4 +1,4 @@
-import { fc } from "@fast-check/vitest";
+import fc from "fast-check";
 
 fc.configureGlobal({
   // This is the default value, but we set it here to be explicit.

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.1",
     "@codecov/vite-plugin": "0.0.1-beta.10",
-    "@fast-check/vitest": "^0.1.0",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/pluginutils": "^5.1.0",
     "@vitest/browser": "^1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@codecov/vite-plugin':
         specifier: 0.0.1-beta.10
         version: 0.0.1-beta.10(vite@5.4.2(@types/node@20.16.1)(terser@5.31.1))
-      '@fast-check/vitest':
-        specifier: ^0.1.0
-        version: 0.1.1(vitest@1.2.2(@types/node@20.16.1)(@vitest/browser@1.2.2)(terser@5.31.1))
       '@rollup/plugin-terser':
         specifier: ^0.4.4
         version: 0.4.4(rollup@4.21.0)
@@ -588,11 +585,6 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
-
-  '@fast-check/vitest@0.1.1':
-    resolution: {integrity: sha512-hxBUieogCiugTY0RZTBcFRfCVja4CxLMXwCKXyf6OtP65gGWoRI17iu/SwcGZp2hzlpxiSIgHFYfQXBEx+jxfQ==}
-    peerDependencies:
-      vitest: '>=0.28.1 <1.0.0 || ^1'
 
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
@@ -3314,11 +3306,6 @@ snapshots:
 
   '@esbuild/win32-x64@0.21.5':
     optional: true
-
-  '@fast-check/vitest@0.1.1(vitest@1.2.2(@types/node@20.16.1)(@vitest/browser@1.2.2)(terser@5.31.1))':
-    dependencies:
-      fast-check: 3.21.0
-      vitest: 1.2.2(@types/node@20.16.1)(@vitest/browser@1.2.2)(terser@5.31.1)
 
   '@iarna/toml@2.2.5': {}
 

--- a/src/Lexer.spec.ts
+++ b/src/Lexer.spec.ts
@@ -1,4 +1,4 @@
-import { fc } from "@fast-check/vitest";
+import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import { Lexer } from "./Lexer.ts";
 import { FC, autoChunk } from "./__tests__/helper.ts";

--- a/src/LexerTransformer.spec.ts
+++ b/src/LexerTransformer.spec.ts
@@ -1,4 +1,4 @@
-import { fc } from "@fast-check/vitest";
+import fc from "fast-check";
 import { describe as describe_, expect, it as it_ } from "vitest";
 import { LexerTransformer } from "./LexerTransformer.ts";
 import { FC, autoChunk, transform } from "./__tests__/helper.ts";

--- a/src/RecordAssembler.spec.ts
+++ b/src/RecordAssembler.spec.ts
@@ -1,4 +1,4 @@
-import { fc } from "@fast-check/vitest";
+import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import { RecordAssembler } from "./RecordAssembler.ts";
 import { FC } from "./__tests__/helper.ts";

--- a/src/RecordAssemblerTransformer.spec.ts
+++ b/src/RecordAssemblerTransformer.spec.ts
@@ -1,4 +1,4 @@
-import { fc } from "@fast-check/vitest";
+import fc from "fast-check";
 import { describe as describe_, expect, it as it_, vi } from "vitest";
 import { RecordAssemblerTransformer } from "./RecordAssemblerTransformer.ts";
 import { FC, transform } from "./__tests__/helper.ts";

--- a/src/assertCommonOptions.spec.ts
+++ b/src/assertCommonOptions.spec.ts
@@ -1,4 +1,4 @@
-import { fc } from "@fast-check/vitest";
+import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import { FC } from "./__tests__/helper.ts";
 import { assertCommonOptions } from "./assertCommonOptions.ts";

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -1,4 +1,4 @@
-import { fc } from "@fast-check/vitest";
+import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import { FC } from "./__tests__/helper.ts";
 import { escapeField } from "./escapeField.ts";

--- a/src/parseBinary.spec.ts
+++ b/src/parseBinary.spec.ts
@@ -1,4 +1,4 @@
-import { fc } from "@fast-check/vitest";
+import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import { FC } from "./__tests__/helper.ts";
 import { escapeField } from "./escapeField.ts";

--- a/src/parseResponse.spec.ts
+++ b/src/parseResponse.spec.ts
@@ -1,4 +1,4 @@
-import { fc } from "@fast-check/vitest";
+import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import { FC } from "./__tests__/helper.ts";
 import { escapeField } from "./escapeField.ts";

--- a/src/parseResponseToStream.spec.ts
+++ b/src/parseResponseToStream.spec.ts
@@ -1,4 +1,4 @@
-import { fc } from "@fast-check/vitest";
+import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import { FC } from "./__tests__/helper";
 import { escapeField } from "./escapeField";

--- a/src/parseString.spec.ts
+++ b/src/parseString.spec.ts
@@ -1,4 +1,4 @@
-import { fc } from "@fast-check/vitest";
+import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import { FC } from "./__tests__/helper.ts";
 import { escapeField } from "./escapeField.ts";

--- a/src/parseStringStream.spec.ts
+++ b/src/parseStringStream.spec.ts
@@ -1,4 +1,4 @@
-import { fc } from "@fast-check/vitest";
+import fc from "fast-check";
 import { describe, expect, it, test } from "vitest";
 import { FC } from "./__tests__/helper.ts";
 import { escapeField } from "./escapeField.ts";

--- a/src/parseStringToArraySyncWASM.spec.ts
+++ b/src/parseStringToArraySyncWASM.spec.ts
@@ -1,4 +1,4 @@
-import { fc } from "@fast-check/vitest";
+import fc from "fast-check";
 import { beforeAll, describe, expect, it } from "vitest";
 import { FC } from "./__tests__/helper.ts";
 import { escapeField } from "./escapeField.ts";

--- a/src/parseUint8ArrayStream.spec.ts
+++ b/src/parseUint8ArrayStream.spec.ts
@@ -1,4 +1,4 @@
-import { fc } from "@fast-check/vitest";
+import fc from "fast-check";
 import { describe, expect, it, test } from "vitest";
 import { FC } from "./__tests__/helper.ts";
 import { escapeField } from "./escapeField.ts";


### PR DESCRIPTION
This pull request replaces the `@fast-check/vitest` package with the `fast-check` package across the codebase for property-based testing. The changes include updating imports, removing the dependency on `@fast-check/vitest`, and modifying configuration files accordingly.

### Dependency Replacement:
* Removed `@fast-check/vitest` from `package.json` and `pnpm-lock.yaml`, and added `fast-check` as the replacement. This simplifies dependency management by using the main `fast-check` package directly. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L102) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL23-L25) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL592-L596) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3318-L3322)

### Code Updates:
* Updated imports in all test files to use `fast-check` instead of `@fast-check/vitest`. This affects multiple test files, including `src/Lexer.spec.ts`, `src/LexerTransformer.spec.ts`, and others. [[1]](diffhunk://#diff-7e9d82e6fcaecdc1c0247b265539950a8923179838095b934766bdf4343684e9L1-R1) [[2]](diffhunk://#diff-82a43023445915b6957d9c8934e651142691bd41a8dc274c2cd022fafebe273fL1-R1) [[3]](diffhunk://#diff-4bb122055da3adc6f456de1179ca76bf06c66ce4638e16331201d0af1a81ef58L1-R1) [[4]](diffhunk://#diff-81a83aaf7a0b42c30eda5af2d4a3ce7590de177df7f599941611058914290374L1-R1) [[5]](diffhunk://#diff-ed73ed4bf0a50227aedcb3418c425b8230ff5cdccf3558a792a99bf73738b033L1-R1) [[6]](diffhunk://#diff-3d54d28cbcb2345bb50754d6455d5de8b622b17334fd010d0a55cdd91002eb3bL1-R1) [[7]](diffhunk://#diff-d01e83e252a047210a32e969a0e39eb34bdf5148c1219b2f25df87a966bd7fa1L1-R1) [[8]](diffhunk://#diff-51a3c0dfc995a28a30316e9768114f09ed116a46639c0606b574efd60ecf1cbbL1-R1) [[9]](diffhunk://#diff-f66831a44a2a484a0aeb0619b7968c0d3765bccf14662330434fd6142fd20a4dL1-R1) [[10]](diffhunk://#diff-2f4cc9d3cccfd7abebe0030ece3eaaa5ee7d50571ecd85ea49c4d4b494b5d70fL1-R1) [[11]](diffhunk://#diff-59be23b90e03ad097cbe4bdcef4cb6caa97bbf3185f062ea07212a86c0b3ba28L1-R1)

### Configuration Changes:
* Updated `vitest.setup.ts` to configure the global settings for `fast-check` instead of `@fast-check/vitest`. This ensures compatibility with the new package.

### Documentation:
* Added a changeset file to document the update and specify that it is a patch release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated test files to use a different property-based testing library.
  - Removed an unused testing dependency from the development environment.

- **Tests**
  - Adjusted import statements in all test files to ensure compatibility with the new testing library. No changes were made to test logic or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->