### PR TITLE
Drop support Node.js v18 and Add test on Node.js v24

### DIFF
--- a/.changeset/tidy-bats-fly.md
+++ b/.changeset/tidy-bats-fly.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": minor
+---
+
+Drop support Node.js v18 and Add test on Node.js v24

--- a/.github/workflows/.dynamic-tests.yaml
+++ b/.github/workflows/.dynamic-tests.yaml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "unpkg": "dist/web-csv-toolbox.umd.js",
   "packageManager": "pnpm@9.3.0",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "sideEffects": false,
   "exports": {


### PR DESCRIPTION
This pull request updates the Node.js version support for the `web-csv-toolbox` project. It drops support for Node.js v18, adds support for Node.js v24, and updates the testing matrix and engine requirements accordingly.

### Node.js version updates:

* Added a changeset entry to document the drop of Node.js v18 support and the addition of testing for Node.js v24.
* Updated the testing matrix to include Node.js versions 20.x, 22.x, and 24.x, while removing 18.x.
* Updated the `engines.node` field to require Node.js v20.0.0 or higher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated minimum required Node.js version to 20.
  - Removed support for Node.js 18 and added testing support for Node.js 24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->