### PR TITLE
Migrate npm package publishing to OIDC trusted publishing

### DIFF
--- a/.changeset/migrate-npm-oidc.md
+++ b/.changeset/migrate-npm-oidc.md
@@ -1,0 +1,5 @@
+---
+"web-csv-toolbox": patch
+---
+
+Migrate npm package publishing to OIDC trusted publishing for enhanced security

--- a/.github/workflows/.release.yaml
+++ b/.github/workflows/.release.yaml
@@ -2,16 +2,13 @@ name: Release
 
 on:
   workflow_call:
-    secrets:
-      NPM_TOKEN:
-        required: true
-        description: The token to publish to npm
 
 jobs:
   # Release the package to npm
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: npm
     permissions:
       contents: write # Used to commit to "Version Packages" PR
       pull-requests: write # Used to create "Version Packages" PR
@@ -34,13 +31,13 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     outputs:
       published: ${{ steps.changesets.outputs.published }}
   # If the release job not published, run this job to publish a prerelease
   prerelease:
     name: Prerelease
     runs-on: ubuntu-latest
+    environment: npm
     permissions:
       contents: read
       id-token: write
@@ -53,15 +50,8 @@ jobs:
         with:
           skip-rust-setup: 'true'
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-      - name: Creating .npmrc
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        run: |
-          cat << EOF > "$HOME/.npmrc"
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          EOF
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: "Release @next"
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: |
           pnpm exec changeset version --snapshot next
           pnpm exec changeset publish --no-git-tag --snapshot --tag next

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,5 +41,3 @@ jobs:
       - build
       - dynamic_tests
     if: ${{ github.repository == 'kamiazya/web-csv-toolbox' && github.ref == 'refs/heads/main' && success() }}
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "unpkg": "dist/web-csv-toolbox.umd.js",
   "packageManager": "pnpm@9.3.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.0.0",
+    "npm": ">=11.5.1"
   },
   "sideEffects": false,
   "exports": {


### PR DESCRIPTION
## Summary

This PR migrates the npm package publishing workflow from using long-lived `NPM_TOKEN` secrets to OIDC (OpenID Connect) trusted publishing.

## Changes

- **Security Enhancement**: Replace long-lived authentication tokens with ephemeral, workflow-specific credentials
- **Workflow Updates**:
  - Add `environment: npm` to release and prerelease jobs in `.github/workflows/.release.yaml`
  - Remove `NPM_TOKEN` secret dependencies from all workflows
  - Remove manual `.npmrc` creation in prerelease job
- **Package Configuration**: Add npm engine requirement (`>=11.5.1`) in `package.json` to ensure OIDC support

## Benefits

- ✅ Eliminates long-lived authentication tokens
- ✅ Automatic provenance attestations
- ✅ Reduces risk of token exposure
- ✅ Aligns with GitHub and npm security best practices

## Test plan

- [x] Verify CI workflows pass successfully
- [x] Confirm npm environment is created in GitHub settings
- [ ] Test release workflow with OIDC authentication after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened npm publishing security through OIDC-based trusted publishing, improving release workflow safety
  * Updated npm engine requirement to version 11.5.1 or later

<!-- end of auto-generated comment: release notes by coderabbit.ai -->