### PR TITLE
bug(csv): Add comprehensive test cases and fix bug for CRLF/LF line ending compatibility

### DIFF
--- a/src/Lexer.spec.ts
+++ b/src/Lexer.spec.ts
@@ -77,6 +77,7 @@ describe("class Lexer", () => {
       ),
     );
   });
+
   it("should lex with comma as a default field delimiter", () => {
     fc.assert(
       fc.property(

--- a/src/Lexer.spec.ts
+++ b/src/Lexer.spec.ts
@@ -21,62 +21,60 @@ const LOCATION_SHAPE = {
 };
 
 describe("class Lexer", () => {
+  it("should tokenize record delimiters correctly for various EOL (property test)", () => {
+    fc.assert(
+      fc.property(
+        fc.gen().map((g) => {
+          const options = g(FC.commonOptions);
+          const eol = g(FC.eol);
+          const data = g(FC.csvData, {
+            fieldConstraints: { minLength: 1 },
+            rowsConstraints: { minLength: 1 },
+            columnsConstraints: { minLength: 1 },
+          });
+          const csv = data
+            .map((row) =>
+              row
+                .map((field) => escapeField(field, { ...options, quote: true }))
+                .join(options.delimiter),
+            )
+            .join(eol);
 
-  it("should tokenize record delimiters correctly for various EOL (property test)", () => {
-    fc.assert(
-      fc.property(
-        fc.gen().map((g) => {
-          const options = g(FC.commonOptions);
-          const eol = g(FC.eol); 
-          const data = g(FC.csvData, {
-            fieldConstraints: { minLength: 1 },
-            rowsConstraints: { minLength: 1 },
-            columnsConstraints: { minLength: 1 },
-          });
-          const csv = 
-            data
-              .map((row) =>
-                row
-                  .map((field) => escapeField(field, { ...options, quote: true }))
-                  .join(options.delimiter),
-              )
-              .join(eol);
-          
-          const expected = [
-            ...data.flatMap((row, i) => [
-              ...row.flatMap((field, j) => [
-                { type: Field, value: field, location: LOCATION_SHAPE },
-                ...(row.length - 1 !== j
-                  ? [
-                      {
-                        type: FieldDelimiter,
-                        value: options.delimiter,
-                        location: LOCATION_SHAPE,
-                      },
-                    ]
-                  : []),
-              ]),
-              ...(data.length - 1 !== i
-                ? [
-                    {
-                      type: RecordDelimiter,
-                      value: eol,
-                      location: LOCATION_SHAPE,
-                    },
-                  ]
-                : []),
-            ]),
-          ];
-          return { csv, options, expected };
-        }),
-        ({ options, csv, expected }) => {
-          const lexer = new Lexer(options);
-          const actual = [...lexer.lex(csv)];
-          expect(actual).toMatchObject(expected);
-        },
-      ),
-    );
-  });
+          const expected = [
+            ...data.flatMap((row, i) => [
+              ...row.flatMap((field, j) => [
+                { type: Field, value: field, location: LOCATION_SHAPE },
+                ...(row.length - 1 !== j
+                  ? [
+                      {
+                        type: FieldDelimiter,
+                        value: options.delimiter,
+                        location: LOCATION_SHAPE,
+                      },
+                    ]
+                  : []),
+              ]),
+              ...(data.length - 1 !== i
+                ? [
+                    {
+                      type: RecordDelimiter,
+                      value: eol,
+                      location: LOCATION_SHAPE,
+                    },
+                  ]
+                : []),
+            ]),
+          ];
+          return { csv, options, expected };
+        }),
+        ({ options, csv, expected }) => {
+          const lexer = new Lexer(options);
+          const actual = [...lexer.lex(csv)];
+          expect(actual).toMatchObject(expected);
+        },
+      ),
+    );
+  });
 
   it("should lex with comma as a default field delimiter", () => {
     fc.assert(
@@ -319,11 +317,11 @@ describe("class Lexer", () => {
             ]),
           ];
           if (data.length > 0 && EOF) {
-              expected.push({ 
-                  type: RecordDelimiter, 
-                  value: eol, 
-                  location: LOCATION_SHAPE
-              });
+            expected.push({
+              type: RecordDelimiter,
+              value: eol,
+              location: LOCATION_SHAPE,
+            });
           }
           return { csv, data, options, expected };
         }),

--- a/src/Lexer.spec.ts
+++ b/src/Lexer.spec.ts
@@ -45,7 +45,7 @@ describe("class Lexer", () => {
           const expected = [
             ...data.flatMap((row, i) => [
               ...row.flatMap((field, j) => [
-                { type: Field, value: field },
+                { type: Field, value: field, location: LOCATION_SHAPE },
                 ...(row.length - 1 !== j
                   ? [
                       {

--- a/src/Lexer.test.ts
+++ b/src/Lexer.test.ts
@@ -11,24 +11,112 @@ describe("Lexer", () => {
   test("should parse mixed CRLF and LF record delimiters correctly", () => {
     const csvMixed = "field1,field2\r\nfield3,field4\nfield5,field6";
     const tokens = lexer.lex(csvMixed);
-    
+
     expect([...tokens]).toStrictEqual([
       // --- Row 1 (Field 1, Delimiter, Field 2) ---
-      { type: Field, value: "field1", location: { start: { line: 1, column: 1, offset: 0 }, end: { line: 1, column: 7, offset: 6 }, rowNumber: 1, } },
-      { type: FieldDelimiter, value: ",", location: { start: { line: 1, column: 7, offset: 6 }, end: { line: 1, column: 8, offset: 7 }, rowNumber: 1, } },
-      { type: Field, value: "field2", location: { start: { line: 1, column: 8, offset: 7 }, end: { line: 1, column: 14, offset: 13 }, rowNumber: 1, } },
+      {
+        type: Field,
+        value: "field1",
+        location: {
+          start: { line: 1, column: 1, offset: 0 },
+          end: { line: 1, column: 7, offset: 6 },
+          rowNumber: 1,
+        },
+      },
+      {
+        type: FieldDelimiter,
+        value: ",",
+        location: {
+          start: { line: 1, column: 7, offset: 6 },
+          end: { line: 1, column: 8, offset: 7 },
+          rowNumber: 1,
+        },
+      },
+      {
+        type: Field,
+        value: "field2",
+        location: {
+          start: { line: 1, column: 8, offset: 7 },
+          end: { line: 1, column: 14, offset: 13 },
+          rowNumber: 1,
+        },
+      },
       // --- Record Delimiter 1 (CRLF) ---
-      { type: RecordDelimiter, value: "\r\n", location: { start: { line: 1, column: 14, offset: 13 }, end: { line: 2, column: 1, offset: 15 }, rowNumber: 1, } }, 
+      {
+        type: RecordDelimiter,
+        value: "\r\n",
+        location: {
+          start: { line: 1, column: 14, offset: 13 },
+          end: { line: 2, column: 1, offset: 15 },
+          rowNumber: 1,
+        },
+      },
       // --- Row 2 (Field 3, Delimiter, Field 4) ---
-      { type: Field, value: "field3", location: { start: { line: 2, column: 1, offset: 15 }, end: { line: 2, column: 7, offset: 21 }, rowNumber: 2, } },
-      { type: FieldDelimiter, value: ",", location: { start: { line: 2, column: 7, offset: 21 }, end: { line: 2, column: 8, offset: 22 }, rowNumber: 2, } },
-      { type: Field, value: "field4", location: { start: { line: 2, column: 8, offset: 22 }, end: { line: 2, column: 14, offset: 28 }, rowNumber: 2, } },
+      {
+        type: Field,
+        value: "field3",
+        location: {
+          start: { line: 2, column: 1, offset: 15 },
+          end: { line: 2, column: 7, offset: 21 },
+          rowNumber: 2,
+        },
+      },
+      {
+        type: FieldDelimiter,
+        value: ",",
+        location: {
+          start: { line: 2, column: 7, offset: 21 },
+          end: { line: 2, column: 8, offset: 22 },
+          rowNumber: 2,
+        },
+      },
+      {
+        type: Field,
+        value: "field4",
+        location: {
+          start: { line: 2, column: 8, offset: 22 },
+          end: { line: 2, column: 14, offset: 28 },
+          rowNumber: 2,
+        },
+      },
       // --- Record Delimiter 2 (LF) ---
-      { type: RecordDelimiter, value: "\n", location: { start: { line: 2, column: 14, offset: 28 }, end: { line: 3, column: 1, offset: 29 }, rowNumber: 2, } }, 
+      {
+        type: RecordDelimiter,
+        value: "\n",
+        location: {
+          start: { line: 2, column: 14, offset: 28 },
+          end: { line: 3, column: 1, offset: 29 },
+          rowNumber: 2,
+        },
+      },
       // --- Row 3 (Field 5, Delimiter, Field 6) ---
-      { type: Field, value: "field5", location: { start: { line: 3, column: 1, offset: 29 }, end: { line: 3, column: 7, offset: 35 }, rowNumber: 3, } },
-      { type: FieldDelimiter, value: ",", location: { start: { line: 3, column: 7, offset: 35 }, end: { line: 3, column: 8, offset: 36 }, rowNumber: 3, } },
-      { type: Field, value: "field6", location: { start: { line: 3, column: 8, offset: 36 }, end: { line: 3, column: 14, offset: 42 }, rowNumber: 3, } },
+      {
+        type: Field,
+        value: "field5",
+        location: {
+          start: { line: 3, column: 1, offset: 29 },
+          end: { line: 3, column: 7, offset: 35 },
+          rowNumber: 3,
+        },
+      },
+      {
+        type: FieldDelimiter,
+        value: ",",
+        location: {
+          start: { line: 3, column: 7, offset: 35 },
+          end: { line: 3, column: 8, offset: 36 },
+          rowNumber: 3,
+        },
+      },
+      {
+        type: Field,
+        value: "field6",
+        location: {
+          start: { line: 3, column: 8, offset: 36 },
+          end: { line: 3, column: 14, offset: 42 },
+          rowNumber: 3,
+        },
+      },
     ]);
   });
 

--- a/src/Lexer.test.ts
+++ b/src/Lexer.test.ts
@@ -8,6 +8,30 @@ describe("Lexer", () => {
     lexer = new Lexer();
   });
 
+  test("should parse mixed CRLF and LF record delimiters correctly", () => {
+    const csvMixed = "field1,field2\r\nfield3,field4\nfield5,field6";
+    const tokens = lexer.lex(csvMixed);
+    
+    expect([...tokens]).toStrictEqual([
+      // --- Row 1 (Field 1, Delimiter, Field 2) ---
+      { type: Field, value: "field1", location: { start: { line: 1, column: 1, offset: 0 }, end: { line: 1, column: 7, offset: 6 }, rowNumber: 1, } },
+      { type: FieldDelimiter, value: ",", location: { start: { line: 1, column: 7, offset: 6 }, end: { line: 1, column: 8, offset: 7 }, rowNumber: 1, } },
+      { type: Field, value: "field2", location: { start: { line: 1, column: 8, offset: 7 }, end: { line: 1, column: 14, offset: 13 }, rowNumber: 1, } },
+      // --- Record Delimiter 1 (CRLF) ---
+      { type: RecordDelimiter, value: "\r\n", location: { start: { line: 1, column: 14, offset: 13 }, end: { line: 2, column: 1, offset: 15 }, rowNumber: 1, } }, 
+      // --- Row 2 (Field 3, Delimiter, Field 4) ---
+      { type: Field, value: "field3", location: { start: { line: 2, column: 1, offset: 15 }, end: { line: 2, column: 7, offset: 21 }, rowNumber: 2, } },
+      { type: FieldDelimiter, value: ",", location: { start: { line: 2, column: 7, offset: 21 }, end: { line: 2, column: 8, offset: 22 }, rowNumber: 2, } },
+      { type: Field, value: "field4", location: { start: { line: 2, column: 8, offset: 22 }, end: { line: 2, column: 14, offset: 28 }, rowNumber: 2, } },
+      // --- Record Delimiter 2 (LF) ---
+      { type: RecordDelimiter, value: "\n", location: { start: { line: 2, column: 14, offset: 28 }, end: { line: 3, column: 1, offset: 29 }, rowNumber: 2, } }, 
+      // --- Row 3 (Field 5, Delimiter, Field 6) ---
+      { type: Field, value: "field5", location: { start: { line: 3, column: 1, offset: 29 }, end: { line: 3, column: 7, offset: 35 }, rowNumber: 3, } },
+      { type: FieldDelimiter, value: ",", location: { start: { line: 3, column: 7, offset: 35 }, end: { line: 3, column: 8, offset: 36 }, rowNumber: 3, } },
+      { type: Field, value: "field6", location: { start: { line: 3, column: 8, offset: 36 }, end: { line: 3, column: 14, offset: 42 }, rowNumber: 3, } },
+    ]);
+  });
+
   test("should parse a field with not escaped", () => {
     const tokens = lexer.lex("field");
     expect([...tokens]).toStrictEqual([
@@ -125,6 +149,15 @@ describe("Lexer", () => {
           rowNumber: 2,
         },
       },
+      {
+        type: RecordDelimiter,
+        value: "\n",
+        location: {
+          start: { line: 3, column: 12, offset: 20 },
+          end: { line: 4, column: 1, offset: 21 },
+          rowNumber: 2,
+        },
+      },
     ]);
   });
 
@@ -155,6 +188,15 @@ describe("Lexer", () => {
         location: {
           start: { line: 3, column: 1, offset: 11 },
           end: { line: 3, column: 12, offset: 22 },
+          rowNumber: 2,
+        },
+      },
+      {
+        type: RecordDelimiter,
+        value: "\r\n",
+        location: {
+          start: { line: 3, column: 12, offset: 22 },
+          end: { line: 4, column: 1, offset: 24 },
           rowNumber: 2,
         },
       },

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -93,7 +93,6 @@ export class Lexer<
    * @yields Tokens from the buffered CSV data.
    */
   *#tokens(): Generator<Token> {
-
     let token: Token | null;
     while ((token = this.#nextToken())) {
       yield token;
@@ -156,23 +155,23 @@ export class Lexer<
     }
 
     // Check for Delimiter
-    if (this.#buffer.startsWith(this.#delimiter)) {
+    if (this.#buffer.startsWith(this.#delimiter)) {
       // FIX: Slice the buffer by the full delimiter length
-      this.#buffer = this.#buffer.slice(this.#fieldDelimiterLength); 
-      const start: Position = { ...this.#cursor };
+      this.#buffer = this.#buffer.slice(this.#fieldDelimiterLength);
+      const start: Position = { ...this.#cursor };
       // FIX: Advance the column/offset by the full delimiter length
-      this.#cursor.column += this.#fieldDelimiterLength;
-      this.#cursor.offset += this.#fieldDelimiterLength; 
-      return {
-        type: FieldDelimiter,
-        value: this.#delimiter,
-        location: {
-          start,
-          end: { ...this.#cursor },
-          rowNumber: this.#rowNumber,
-        },
-      };
-    }
+      this.#cursor.column += this.#fieldDelimiterLength;
+      this.#cursor.offset += this.#fieldDelimiterLength;
+      return {
+        type: FieldDelimiter,
+        value: this.#delimiter,
+        location: {
+          start,
+          end: { ...this.#cursor },
+          rowNumber: this.#rowNumber,
+        },
+      };
+    }
 
     // Check for Quoted String
     if (this.#buffer.startsWith(this.#quotation)) {
@@ -277,7 +276,7 @@ export class Lexer<
     const match = this.#matcher.exec(this.#buffer);
     if (match) {
       // When buffering (not flushing) and the match fully consumes the buffer,
-      // defer emission to wait for the next chunk (field may be followed by delimiter/quote)
+      // defer emission to wait for the next chunk (field may be followed by delimiter/quote)
       if (this.#flush === false && match[0].length === this.#buffer.length) {
         return null;
       }

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -157,7 +157,7 @@ export class Lexer<
 
     // Check for Delimiter
     if (this.#buffer.startsWith(this.#delimiter)) {
-      this.#buffer = this.#buffer.slice(1);
+      this.#buffer = this.#buffer.slice(this.#fieldDelimiterLength);
       const start: Position = { ...this.#cursor };
       this.#cursor.column += this.#fieldDelimiterLength;
       this.#cursor.offset += this.#fieldDelimiterLength;

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -93,14 +93,7 @@ export class Lexer<
    * @yields Tokens from the buffered CSV data.
    */
   *#tokens(): Generator<Token> {
-    if (this.#flush) {
-      // Trim the last CRLF or LF
-      if (this.#buffer.endsWith(CRLF)) {
-        this.#buffer = this.#buffer.slice(0, -2 /* -CRLF.length */);
-      } else if (this.#buffer.endsWith(LF)) {
-        this.#buffer = this.#buffer.slice(0, -1 /* -LF.length */);
-      }
-    }
+
     let token: Token | null;
     while ((token = this.#nextToken())) {
       yield token;

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -156,21 +156,23 @@ export class Lexer<
     }
 
     // Check for Delimiter
-    if (this.#buffer.startsWith(this.#delimiter)) {
-      this.#buffer = this.#buffer.slice(this.#fieldDelimiterLength);
-      const start: Position = { ...this.#cursor };
-      this.#cursor.column += this.#fieldDelimiterLength;
-      this.#cursor.offset += this.#fieldDelimiterLength;
-      return {
-        type: FieldDelimiter,
-        value: this.#delimiter,
-        location: {
-          start,
-          end: { ...this.#cursor },
-          rowNumber: this.#rowNumber,
-        },
-      };
-    }
+    if (this.#buffer.startsWith(this.#delimiter)) {
+      // FIX: Slice the buffer by the full delimiter length
+      this.#buffer = this.#buffer.slice(this.#fieldDelimiterLength); 
+      const start: Position = { ...this.#cursor };
+      // FIX: Advance the column/offset by the full delimiter length
+      this.#cursor.column += this.#fieldDelimiterLength;
+      this.#cursor.offset += this.#fieldDelimiterLength; 
+      return {
+        type: FieldDelimiter,
+        value: this.#delimiter,
+        location: {
+          start,
+          end: { ...this.#cursor },
+          rowNumber: this.#rowNumber,
+        },
+      };
+    }
 
     // Check for Quoted String
     if (this.#buffer.startsWith(this.#quotation)) {
@@ -274,8 +276,8 @@ export class Lexer<
     // Check for Unquoted String
     const match = this.#matcher.exec(this.#buffer);
     if (match) {
-      // If we're flushing and the match doesn't consume the entire buffer,
-      // then return null
+      // When buffering (not flushing) and the match fully consumes the buffer,
+      // defer emission to wait for the next chunk (field may be followed by delimiter/quote)
       if (this.#flush === false && match[0].length === this.#buffer.length) {
         return null;
       }

--- a/src/LexerTransformer.spec.ts
+++ b/src/LexerTransformer.spec.ts
@@ -161,20 +161,20 @@ describe("LexerTransformer", () => {
       ),
       {
         examples: [
-          [
-            // The single EOL must now be tokenized correctly by the fixed Lexer
-            {
-              options: { delimiter: ",", quotation: '"' },
-              chunks: ["\n"],
-              expected: [
-                {
-                  type: RecordDelimiter,
-                  value: "\n",
-                  location: LOCATION_SHAPE, 
-                },
-              ],
-            },
-          ],
+          [
+            // The single EOL must now be tokenized correctly by the fixed Lexer
+            {
+              options: { delimiter: ",", quotation: '"' },
+              chunks: ["\n"],
+              expected: [
+                {
+                  type: RecordDelimiter,
+                  value: "\n",
+                  location: LOCATION_SHAPE,
+                },
+              ],
+            },
+          ],
         ],
       },
     );

--- a/src/LexerTransformer.spec.ts
+++ b/src/LexerTransformer.spec.ts
@@ -161,14 +161,20 @@ describe("LexerTransformer", () => {
       ),
       {
         examples: [
-          [
-            // only EOL is ignored
-            {
-              options: { delimiter: ",", quotation: '"' },
-              chunks: ["\n"],
-              expected: [],
-            },
-          ],
+          [
+            // The single EOL must now be tokenized correctly by the fixed Lexer
+            {
+              options: { delimiter: ",", quotation: '"' },
+              chunks: ["\n"],
+              expected: [
+                {
+                  type: RecordDelimiter,
+                  value: "\n",
+                  location: LOCATION_SHAPE, 
+                },
+              ],
+            },
+          ],
         ],
       },
     );

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -367,4 +367,71 @@ describe("parse function", () => {
         },
       ),
     ));
+    
+async function toArray(csv: string | ReadableStream<string>): Promise<any[]>;
+async function toArray(csv: Uint8Array | ArrayBuffer | ReadableStream<Uint8Array> | Response): Promise<any[]>;
+async function toArray(
+    csv: string | Uint8Array | ArrayBuffer | ReadableStream<any> | Response
+): Promise<any[]> {
+    const records = [];
+    for await (const row of parse(csv as any)) {
+        records.push(row);
+    }
+    return records;
+}
+
+describe('Line Ending Compatibility (CRLF vs LF)', () => {
+  const expectedRecords = [
+    { name: 'Alice', age: '42' },
+    { name: 'Bob', age: '69' },
+    { name: 'Charlie', age: '30' },
+  ];
+  
+  it('should produce identical records for LF and CRLF line endings', async () => {
+    const csvLF = 'name,age\nAlice,42\nBob,69\nCharlie,30';
+    const recordsLF = await toArray(csvLF);
+
+    const csvCRLF = 'name,age\r\nAlice,42\r\nBob,69\r\nCharlie,30';
+    const recordsCRLF = await toArray(csvCRLF);
+
+    expect(recordsLF).toEqual(expectedRecords);
+    expect(recordsCRLF).toEqual(expectedRecords);
+    expect(recordsLF).toEqual(recordsCRLF);
+  });
+
+  it('should handle mixed CRLF and LF line endings gracefully', async () => {
+    const csvMixed = 'name,age\r\nAlice,42\nBob,69\r\nCharlie,30';
+    
+    const recordsMixed = await toArray(csvMixed);
+    
+    expect(recordsMixed).toEqual(expectedRecords);
+  });
+
+  it('should preserve line endings (LF and CRLF) inside quoted fields', async () => {
+    const csv = `name,description\n"Alice","Line1\nLine2"\n"Bob","LineA\r\nLineB"`;
+    
+    const expected = [
+      { name: 'Alice', description: 'Line1\nLine2' },
+      { name: 'Bob', description: 'LineA\r\nLineB' },
+    ];
+    
+    const records = await toArray(csv);
+    
+    expect(records).toEqual(expected);
+  });
+
+  it('should ignore a single trailing line ending (LF or CRLF) but handle double trailing EOL', async () => {
+    const expected = [{ name: 'Alice', age: '42' }];
+
+    const csvWithTrailingLF = 'name,age\nAlice,42\n';
+    expect(await toArray(csvWithTrailingLF)).toEqual(expected);
+
+    const csvWithTrailingCRLF = 'name,age\nAlice,42\r\n';
+    expect(await toArray(csvWithTrailingCRLF)).toEqual(expected);
+    
+    const csvWithDoubleTrailing = 'name,age\nAlice,42\n\n';
+    const expectedWithEmpty = [...expected, { name: '', age: '' }];
+    expect(await toArray(csvWithDoubleTrailing)).toEqual(expectedWithEmpty);
+  });
+});
 });

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -434,19 +434,21 @@ describe('Line Ending Compatibility (CRLF vs LF)', () => {
     const csvWithTrailingCRLF = 'name,age\nAlice,42\r\n';
     expect(await toArray(csvWithTrailingCRLF)).toEqual(expected);
     
-    // 1. LF + LF (Your original passing test)
+    // Double trailing EOL combinations (should produce 2 records)
+    
+    // 1. LF + LF
     const csvWithDoubleTrailingLF = 'name,age\nAlice,42\n\n';
     expect(await toArray(csvWithDoubleTrailingLF)).toEqual(expectedWithEmpty);
     
-    // 2. CRLF + CRLF (New: All Windows)
+    // 2. CRLF + CRLF
     const csvWithDoubleTrailingCRLF = 'name,age\r\nAlice,42\r\n\r\n';
     expect(await toArray(csvWithDoubleTrailingCRLF)).toEqual(expectedWithEmpty);
     
-    // 3. LF + CRLF (New: Mixed)
+    // 3. LF + CRLF (Mixed)
     const csvWithDoubleTrailingMixed1 = 'name,age\nAlice,42\n\r\n';
     expect(await toArray(csvWithDoubleTrailingMixed1)).toEqual(expectedWithEmpty);
     
-    // 4. CRLF + LF (New: Mixed)
+    // 4. CRLF + LF (Mixed)
     const csvWithDoubleTrailingMixed2 = 'name,age\r\nAlice,42\r\n\n';
     expect(await toArray(csvWithDoubleTrailingMixed2)).toEqual(expectedWithEmpty);
   });

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -367,90 +367,98 @@ describe("parse function", () => {
         },
       ),
     ));
-    
-async function toArray(csv: string | ReadableStream<string>): Promise<any[]>;
-async function toArray(csv: Uint8Array | ArrayBuffer | ReadableStream<Uint8Array> | Response): Promise<any[]>;
-async function toArray(
-    csv: string | Uint8Array | ArrayBuffer | ReadableStream<any> | Response
-): Promise<any[]> {
+
+  async function toArray(csv: string | ReadableStream<string>): Promise<any[]>;
+  async function toArray(
+    csv: Uint8Array | ArrayBuffer | ReadableStream<Uint8Array> | Response,
+  ): Promise<any[]>;
+  async function toArray(
+    csv: string | Uint8Array | ArrayBuffer | ReadableStream<any> | Response,
+  ): Promise<any[]> {
     const records = [];
     for await (const row of parse(csv as any)) {
-        records.push(row);
+      records.push(row);
     }
     return records;
-}
+  }
 
-describe('Line Ending Compatibility (CRLF vs LF)', () => {
-  const expectedRecords = [
-    { name: 'Alice', age: '42' },
-    { name: 'Bob', age: '69' },
-    { name: 'Charlie', age: '30' },
-  ];
-  
-  it('should produce identical records for LF and CRLF line endings', async () => {
-    const csvLF = 'name,age\nAlice,42\nBob,69\nCharlie,30';
-    const recordsLF = await toArray(csvLF);
-
-    const csvCRLF = 'name,age\r\nAlice,42\r\nBob,69\r\nCharlie,30';
-    const recordsCRLF = await toArray(csvCRLF);
-
-    expect(recordsLF).toEqual(expectedRecords);
-    expect(recordsCRLF).toEqual(expectedRecords);
-    expect(recordsLF).toEqual(recordsCRLF);
-  });
-
-  it('should handle mixed CRLF and LF line endings gracefully', async () => {
-    const csvMixed = 'name,age\r\nAlice,42\nBob,69\r\nCharlie,30';
-    
-    const recordsMixed = await toArray(csvMixed);
-    
-    expect(recordsMixed).toEqual(expectedRecords);
-  });
-
-  it('should preserve line endings (LF and CRLF) inside quoted fields', async () => {
-    const csv = `name,description\n"Alice","Line1\nLine2"\n"Bob","LineA\r\nLineB"`;
-    
-    const expected = [
-      { name: 'Alice', description: 'Line1\nLine2' },
-      { name: 'Bob', description: 'LineA\r\nLineB' },
+  describe("Line Ending Compatibility (CRLF vs LF)", () => {
+    const expectedRecords = [
+      { name: "Alice", age: "42" },
+      { name: "Bob", age: "69" },
+      { name: "Charlie", age: "30" },
     ];
-    
-    const records = await toArray(csv);
-    
-    expect(records).toEqual(expected);
+
+    it("should produce identical records for LF and CRLF line endings", async () => {
+      const csvLF = "name,age\nAlice,42\nBob,69\nCharlie,30";
+      const recordsLF = await toArray(csvLF);
+
+      const csvCRLF = "name,age\r\nAlice,42\r\nBob,69\r\nCharlie,30";
+      const recordsCRLF = await toArray(csvCRLF);
+
+      expect(recordsLF).toEqual(expectedRecords);
+      expect(recordsCRLF).toEqual(expectedRecords);
+      expect(recordsLF).toEqual(recordsCRLF);
+    });
+
+    it("should handle mixed CRLF and LF line endings gracefully", async () => {
+      const csvMixed = "name,age\r\nAlice,42\nBob,69\r\nCharlie,30";
+
+      const recordsMixed = await toArray(csvMixed);
+
+      expect(recordsMixed).toEqual(expectedRecords);
+    });
+
+    it("should preserve line endings (LF and CRLF) inside quoted fields", async () => {
+      const csv = `name,description\n"Alice","Line1\nLine2"\n"Bob","LineA\r\nLineB"`;
+
+      const expected = [
+        { name: "Alice", description: "Line1\nLine2" },
+        { name: "Bob", description: "LineA\r\nLineB" },
+      ];
+
+      const records = await toArray(csv);
+
+      expect(records).toEqual(expected);
+    });
+
+    it("should ignore a single trailing line ending (LF or CRLF) but handle double trailing EOL", async () => {
+      const expected = [{ name: "Alice", age: "42" }];
+      const expectedWithEmpty = [...expected, { name: "", age: "" }];
+
+      // Single trailing EOLs (should produce 1 record)
+      const csvWithoutTrailing = "name,age\nAlice,42";
+      expect(await toArray(csvWithoutTrailing)).toEqual(expected);
+
+      const csvWithTrailingLF = "name,age\nAlice,42\n";
+      expect(await toArray(csvWithTrailingLF)).toEqual(expected);
+
+      const csvWithTrailingCRLF = "name,age\nAlice,42\r\n";
+      expect(await toArray(csvWithTrailingCRLF)).toEqual(expected);
+
+      // Double trailing EOL combinations (should produce 2 records)
+
+      // 1. LF + LF
+      const csvWithDoubleTrailingLF = "name,age\nAlice,42\n\n";
+      expect(await toArray(csvWithDoubleTrailingLF)).toEqual(expectedWithEmpty);
+
+      // 2. CRLF + CRLF
+      const csvWithDoubleTrailingCRLF = "name,age\r\nAlice,42\r\n\r\n";
+      expect(await toArray(csvWithDoubleTrailingCRLF)).toEqual(
+        expectedWithEmpty,
+      );
+
+      // 3. LF + CRLF (Mixed)
+      const csvWithDoubleTrailingMixed1 = "name,age\nAlice,42\n\r\n";
+      expect(await toArray(csvWithDoubleTrailingMixed1)).toEqual(
+        expectedWithEmpty,
+      );
+
+      // 4. CRLF + LF (Mixed)
+      const csvWithDoubleTrailingMixed2 = "name,age\r\nAlice,42\r\n\n";
+      expect(await toArray(csvWithDoubleTrailingMixed2)).toEqual(
+        expectedWithEmpty,
+      );
+    });
   });
-
-  it('should ignore a single trailing line ending (LF or CRLF) but handle double trailing EOL', async () => {
-    const expected = [{ name: 'Alice', age: '42' }];
-    const expectedWithEmpty = [...expected, { name: '', age: '' }];
-
-    // Single trailing EOLs (should produce 1 record)
-    const csvWithoutTrailing = 'name,age\nAlice,42';
-    expect(await toArray(csvWithoutTrailing)).toEqual(expected);
-
-    const csvWithTrailingLF = 'name,age\nAlice,42\n';
-    expect(await toArray(csvWithTrailingLF)).toEqual(expected);
-
-    const csvWithTrailingCRLF = 'name,age\nAlice,42\r\n';
-    expect(await toArray(csvWithTrailingCRLF)).toEqual(expected);
-    
-    // Double trailing EOL combinations (should produce 2 records)
-    
-    // 1. LF + LF
-    const csvWithDoubleTrailingLF = 'name,age\nAlice,42\n\n';
-    expect(await toArray(csvWithDoubleTrailingLF)).toEqual(expectedWithEmpty);
-    
-    // 2. CRLF + CRLF
-    const csvWithDoubleTrailingCRLF = 'name,age\r\nAlice,42\r\n\r\n';
-    expect(await toArray(csvWithDoubleTrailingCRLF)).toEqual(expectedWithEmpty);
-    
-    // 3. LF + CRLF (Mixed)
-    const csvWithDoubleTrailingMixed1 = 'name,age\nAlice,42\n\r\n';
-    expect(await toArray(csvWithDoubleTrailingMixed1)).toEqual(expectedWithEmpty);
-    
-    // 4. CRLF + LF (Mixed)
-    const csvWithDoubleTrailingMixed2 = 'name,age\r\nAlice,42\r\n\n';
-    expect(await toArray(csvWithDoubleTrailingMixed2)).toEqual(expectedWithEmpty);
-  });
-});
 });

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -422,6 +422,11 @@ describe('Line Ending Compatibility (CRLF vs LF)', () => {
 
   it('should ignore a single trailing line ending (LF or CRLF) but handle double trailing EOL', async () => {
     const expected = [{ name: 'Alice', age: '42' }];
+    const expectedWithEmpty = [...expected, { name: '', age: '' }];
+
+    // Single trailing EOLs (should produce 1 record)
+    const csvWithoutTrailing = 'name,age\nAlice,42';
+    expect(await toArray(csvWithoutTrailing)).toEqual(expected);
 
     const csvWithTrailingLF = 'name,age\nAlice,42\n';
     expect(await toArray(csvWithTrailingLF)).toEqual(expected);
@@ -429,9 +434,21 @@ describe('Line Ending Compatibility (CRLF vs LF)', () => {
     const csvWithTrailingCRLF = 'name,age\nAlice,42\r\n';
     expect(await toArray(csvWithTrailingCRLF)).toEqual(expected);
     
-    const csvWithDoubleTrailing = 'name,age\nAlice,42\n\n';
-    const expectedWithEmpty = [...expected, { name: '', age: '' }];
-    expect(await toArray(csvWithDoubleTrailing)).toEqual(expectedWithEmpty);
+    // 1. LF + LF (Your original passing test)
+    const csvWithDoubleTrailingLF = 'name,age\nAlice,42\n\n';
+    expect(await toArray(csvWithDoubleTrailingLF)).toEqual(expectedWithEmpty);
+    
+    // 2. CRLF + CRLF (New: All Windows)
+    const csvWithDoubleTrailingCRLF = 'name,age\r\nAlice,42\r\n\r\n';
+    expect(await toArray(csvWithDoubleTrailingCRLF)).toEqual(expectedWithEmpty);
+    
+    // 3. LF + CRLF (New: Mixed)
+    const csvWithDoubleTrailingMixed1 = 'name,age\nAlice,42\n\r\n';
+    expect(await toArray(csvWithDoubleTrailingMixed1)).toEqual(expectedWithEmpty);
+    
+    // 4. CRLF + LF (New: Mixed)
+    const csvWithDoubleTrailingMixed2 = 'name,age\r\nAlice,42\r\n\n';
+    expect(await toArray(csvWithDoubleTrailingMixed2)).toEqual(expectedWithEmpty);
   });
 });
 });


### PR DESCRIPTION
**Closes #515**

### Summary of Changes

1.  **Feature Implementation (Tests Added/Updated):**
    * **src/parse.spec.ts:** Added a new `describe('Line Ending Compatibility...')` block with **four end-to-end tests** covering:
        1.  Identical parsing for LF and CRLF inputs.
        2.  Correct graceful handling of mixed LF/CRLF line endings.
        3.  Preservation of LF/CRLF characters within quoted fields.
        4.  Correct handling of single (ignored) vs. double (empty record created) trailing EOLs.
    * **src/Lexer.test.ts:** Added a specific unit test to confirm the Lexer correctly tokenizes mixed LF and CRLF record delimiters, including location data.
    * **src/Lexer.spec.ts:** Added a property-based test using `fast-check` to verify the Lexer's behavior across random EOL combinations.

2.  **Bug Fixes (Required for Tests to Pass):**
    * **Lexer Trimming Bug Fix (src/Lexer.ts):** Removed the incorrect logic in the `*#tokens()` method that was prematurely trimming the final EOL from the buffer. This fix ensures the Lexer properly produces a `RecordDelimiter` token for every EOL found, allowing the parser to correctly generate empty records for double-trailing EOLs (which was failing before).
    * **Test Maintenance:** Updated expectations in several original tests (`src/Lexer.test.ts`, `src/Lexer.spec.ts`) that were incorrectly expecting the final EOL to be trimmed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Final line endings (LF, CRLF, and mixed) are now consistently emitted and tokenized so trailing delimiters and token positions are correct.
  * Delimiter boundary handling improved to preserve accurate token locations, including when fields are empty or quoted.
  * Lone end-of-line now produces a record delimiter token where appropriate.

* **Tests**
  * Added property and example tests for LF/CRLF/mixed endings and single/double trailing endings.
  * Extended expectations to include location metadata; added a helper to collect parse results from multiple input types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->