### PR TITLE
fix: macOS browser timeout - Extract only required properties for WorkerSession

### DIFF
--- a/src/execution/worker/parseBinaryInWorker.node.ts
+++ b/src/execution/worker/parseBinaryInWorker.node.ts
@@ -22,7 +22,12 @@ export async function* parseBinaryInWorker<
   options?: ParseBinaryOptions<Header, Delimiter, Quotation>,
 ): AsyncIterableIterator<CSVRecord<Header>> {
   using session = await WorkerSession.create(
-    options?.engine?.worker === true ? options.engine : undefined,
+    options?.engine?.worker === true
+      ? {
+          workerURL: options.engine.workerURL,
+          workerPool: options.engine.workerPool,
+        }
+      : undefined,
   );
 
   yield* sendWorkerMessage<CSVRecord<Header>>(

--- a/src/execution/worker/parseBinaryInWorker.web.ts
+++ b/src/execution/worker/parseBinaryInWorker.web.ts
@@ -22,7 +22,12 @@ export async function* parseBinaryInWorker<
   options?: ParseBinaryOptions<Header, Delimiter, Quotation>,
 ): AsyncIterableIterator<CSVRecord<Header>> {
   using session = await WorkerSession.create(
-    options?.engine?.worker === true ? options.engine : undefined,
+    options?.engine?.worker === true
+      ? {
+          workerURL: options.engine.workerURL,
+          workerPool: options.engine.workerPool,
+        }
+      : undefined,
   );
 
   yield* sendWorkerMessage<CSVRecord<Header>>(

--- a/src/execution/worker/parseBinaryInWorkerWASM.node.ts
+++ b/src/execution/worker/parseBinaryInWorkerWASM.node.ts
@@ -22,7 +22,12 @@ export async function* parseBinaryInWorkerWASM<
   options?: ParseBinaryOptions<Header, Delimiter, Quotation>,
 ): AsyncIterableIterator<CSVRecord<Header>> {
   using session = await WorkerSession.create(
-    options?.engine?.worker === true ? options.engine : undefined,
+    options?.engine?.worker === true
+      ? {
+          workerURL: options.engine.workerURL,
+          workerPool: options.engine.workerPool,
+        }
+      : undefined,
   );
 
   yield* sendWorkerMessage<CSVRecord<Header>>(

--- a/src/execution/worker/parseBinaryInWorkerWASM.web.ts
+++ b/src/execution/worker/parseBinaryInWorkerWASM.web.ts
@@ -22,7 +22,12 @@ export async function* parseBinaryInWorkerWASM<
   options?: ParseBinaryOptions<Header, Delimiter, Quotation>,
 ): AsyncIterableIterator<CSVRecord<Header>> {
   using session = await WorkerSession.create(
-    options?.engine?.worker === true ? options.engine : undefined,
+    options?.engine?.worker === true
+      ? {
+          workerURL: options.engine.workerURL,
+          workerPool: options.engine.workerPool,
+        }
+      : undefined,
   );
 
   yield* sendWorkerMessage<CSVRecord<Header>>(

--- a/src/execution/worker/parseStreamInWorker.node.ts
+++ b/src/execution/worker/parseStreamInWorker.node.ts
@@ -33,7 +33,12 @@ export async function* parseStreamInWorker<
   const csvString = await collectStringStream(stream, options?.signal);
 
   using session = await WorkerSession.create(
-    options?.engine?.worker === true ? options.engine : undefined,
+    options?.engine?.worker === true
+      ? {
+          workerURL: options.engine.workerURL,
+          workerPool: options.engine.workerPool,
+        }
+      : undefined,
   );
 
   yield* sendWorkerMessage<CSVRecord<Header>>(

--- a/src/execution/worker/parseStreamInWorker.web.ts
+++ b/src/execution/worker/parseStreamInWorker.web.ts
@@ -27,7 +27,12 @@ export async function* parseStreamInWorker<
   options?: ParseOptions<Header, Delimiter, Quotation>,
 ): AsyncIterableIterator<CSVRecord<Header>> {
   using session = await WorkerSession.create(
-    options?.engine?.worker === true ? options.engine : undefined,
+    options?.engine?.worker === true
+      ? {
+          workerURL: options.engine.workerURL,
+          workerPool: options.engine.workerPool,
+        }
+      : undefined,
   );
 
   yield* sendWorkerMessage<CSVRecord<Header>>(

--- a/src/execution/worker/parseStringInWorker.node.ts
+++ b/src/execution/worker/parseStringInWorker.node.ts
@@ -25,7 +25,12 @@ export async function* parseStringInWorker<
   options?: ParseOptions<Header, Delimiter, Quotation>,
 ): AsyncIterableIterator<CSVRecord<Header>> {
   using session = await WorkerSession.create(
-    options?.engine?.worker === true ? options.engine : undefined,
+    options?.engine?.worker === true
+      ? {
+          workerURL: options.engine.workerURL,
+          workerPool: options.engine.workerPool,
+        }
+      : undefined,
   );
 
   yield* sendWorkerMessage<CSVRecord<Header>>(

--- a/src/execution/worker/parseStringInWorker.web.ts
+++ b/src/execution/worker/parseStringInWorker.web.ts
@@ -25,7 +25,12 @@ export async function* parseStringInWorker<
   options?: ParseOptions<Header, Delimiter, Quotation>,
 ): AsyncIterableIterator<CSVRecord<Header>> {
   using session = await WorkerSession.create(
-    options?.engine?.worker === true ? options.engine : undefined,
+    options?.engine?.worker === true
+      ? {
+          workerURL: options.engine.workerURL,
+          workerPool: options.engine.workerPool,
+        }
+      : undefined,
   );
 
   yield* sendWorkerMessage<CSVRecord<Header>>(

--- a/src/execution/worker/parseStringInWorkerWASM.node.ts
+++ b/src/execution/worker/parseStringInWorkerWASM.node.ts
@@ -22,7 +22,12 @@ export async function* parseStringInWorkerWASM<
   options?: ParseOptions<Header, Delimiter, Quotation>,
 ): AsyncIterableIterator<CSVRecord<Header>> {
   using session = await WorkerSession.create(
-    options?.engine?.worker === true ? options.engine : undefined,
+    options?.engine?.worker === true
+      ? {
+          workerURL: options.engine.workerURL,
+          workerPool: options.engine.workerPool,
+        }
+      : undefined,
   );
 
   yield* sendWorkerMessage<CSVRecord<Header>>(

--- a/src/execution/worker/parseStringInWorkerWASM.web.ts
+++ b/src/execution/worker/parseStringInWorkerWASM.web.ts
@@ -22,7 +22,12 @@ export async function* parseStringInWorkerWASM<
   options?: ParseOptions<Header, Delimiter, Quotation>,
 ): AsyncIterableIterator<CSVRecord<Header>> {
   using session = await WorkerSession.create(
-    options?.engine?.worker === true ? options.engine : undefined,
+    options?.engine?.worker === true
+      ? {
+          workerURL: options.engine.workerURL,
+          workerPool: options.engine.workerPool,
+        }
+      : undefined,
   );
 
   yield* sendWorkerMessage<CSVRecord<Header>>(

--- a/src/execution/worker/parseUint8ArrayStreamInWorker.node.ts
+++ b/src/execution/worker/parseUint8ArrayStreamInWorker.node.ts
@@ -30,7 +30,12 @@ export async function* parseUint8ArrayStreamInWorker<
   const combined = await collectUint8ArrayStream(stream, options?.signal);
 
   using session = await WorkerSession.create(
-    options?.engine?.worker === true ? options.engine : undefined,
+    options?.engine?.worker === true
+      ? {
+          workerURL: options.engine.workerURL,
+          workerPool: options.engine.workerPool,
+        }
+      : undefined,
   );
 
   yield* sendWorkerMessage<CSVRecord<Header>>(

--- a/src/execution/worker/parseUint8ArrayStreamInWorker.web.ts
+++ b/src/execution/worker/parseUint8ArrayStreamInWorker.web.ts
@@ -24,7 +24,12 @@ export async function* parseUint8ArrayStreamInWorker<
   options?: ParseBinaryOptions<Header, Delimiter, Quotation>,
 ): AsyncIterableIterator<CSVRecord<Header>> {
   using session = await WorkerSession.create(
-    options?.engine?.worker === true ? options.engine : undefined,
+    options?.engine?.worker === true
+      ? {
+          workerURL: options.engine.workerURL,
+          workerPool: options.engine.workerPool,
+        }
+      : undefined,
   );
 
   yield* sendWorkerMessage<CSVRecord<Header>>(


### PR DESCRIPTION
## Problem

After merging main into ci/add-type-test, macOS browser tests started timing out in worker-based parsing tests (parseBinary).

## Root Cause

`WorkerSession.create()` expects `WorkerSessionOptions` which only contains:
- `workerURL?`: Custom worker URL
- `workerPool?`: Worker pool for reusable workers

However, the code was passing the entire `WorkerEngineConfig` object which includes additional properties:
- `worker`: boolean flag
- `workerStrategy`: Communication strategy
- `strict`: Strict mode flag
- `onFallback`: Fallback callback
- `wasm`, `arrayBufferThreshold`, etc.

## Solution

Extract only `workerURL` and `workerPool` properties when creating WorkerSession:

```typescript
using session = await WorkerSession.create(
  options?.engine?.worker === true
    ? {
        workerURL: options.engine.workerURL,
        workerPool: options.engine.workerPool,
      }
    : undefined,
);
```

## Files Changed

- All worker execution files (12 files total):
  - `src/execution/worker/parseBinaryInWorker.{node,web}.ts`
  - `src/execution/worker/parseBinaryInWorkerWASM.{node,web}.ts`
  - `src/execution/worker/parseStreamInWorker.{node,web}.ts`
  - `src/execution/worker/parseStringInWorker.{node,web}.ts`
  - `src/execution/worker/parseStringInWorkerWASM.{node,web}.ts`
  - `src/execution/worker/parseUint8ArrayStreamInWorker.{node,web}.ts`

## Testing

This fix should resolve the macOS browser test timeouts. Will verify in CI.