### PR TITLE
fix: update release workflow to use setup-typescript action

### DIFF
--- a/.github/workflows/.release.yaml
+++ b/.github/workflows/.release.yaml
@@ -17,10 +17,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Setup
-        uses: ./.github/actions/setup
-        with:
-          skip-rust-setup: 'true'
+      - name: Setup TypeScript
+        uses: ./.github/actions/setup-typescript
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
       - name: Create Release Pull Request or Publish to npm
         id: changesets
@@ -45,10 +43,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Setup
-        uses: ./.github/actions/setup
-        with:
-          skip-rust-setup: 'true'
+      - name: Setup TypeScript
+        uses: ./.github/actions/setup-typescript
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
       - name: "Release @next"
         if: ${{ github.actor != 'dependabot[bot]' }}


### PR DESCRIPTION
## Summary

- Fix release workflow failure by updating composite action reference from removed `.github/actions/setup` to `.github/actions/setup-typescript`

## Background

The release workflow was failing with the following error:
```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/web-csv-toolbox/web-csv-toolbox/.github/actions/setup'.
```

This occurred because the `.github/actions/setup` composite action was removed during the recent CI refactoring in #588 (commit 58879be), where it was split into three environment-specific actions:
- `setup-rust`: For Rust/WASM environment
- `setup-typescript`: For TypeScript/Node.js environment  
- `setup-full`: For full environment (both Rust and TypeScript)

## Changes

Updated `.github/workflows/.release.yaml`:
- `release` job (line 21): Changed from `.github/actions/setup` to `.github/actions/setup-typescript`
- `prerelease` job (line 47): Changed from `.github/actions/setup` to `.github/actions/setup-typescript`
- Removed the now-unnecessary `skip-rust-setup: 'true'` parameter

The `setup-typescript` action is the appropriate choice for the release workflow since it only needs Node.js/pnpm to publish to npm.

## Verification

- Confirmed no other workflow files reference the removed `.github/actions/setup` action
- The change is consistent with other workflows (e.g., `.build.yaml` uses `setup-typescript` for TypeScript builds)

## Test plan

- [ ] Workflow should pass when this PR is merged to main
- [ ] Next release should complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to use TypeScript-specific setup actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->