### PR TITLE
fix: resolve node-version warning in setup-typescript action

### DIFF
--- a/.github/actions/setup-typescript/action.yaml
+++ b/.github/actions/setup-typescript/action.yaml
@@ -13,10 +13,17 @@ runs:
     - name: Setup pnpm
       uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
-    - name: Setup Node.js
+    - name: Setup Node.js (with specified version)
+      if: ${{ inputs.node-version != '' }}
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: ${{ inputs.node-version }}
+        cache: pnpm
+
+    - name: Setup Node.js (from .node-version file)
+      if: ${{ inputs.node-version == '' }}
+      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      with:
         node-version-file: ./.node-version
         cache: pnpm
 


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions warning: "Both node-version and node-version-file inputs are specified, only node-version will be used"

## Changes

- Split the "Setup Node.js" step into two conditional steps in `.github/actions/setup-typescript/action.yaml`:
  - One step for when `node-version` input is specified (e.g., in matrix tests)
  - One step for when using `.node-version` file (default behavior)
- This ensures only one version specification method is used at a time

## Test plan

- [ ] Verify CI passes without warnings
- [ ] Check that Node.js Tests job no longer shows the warning
- [ ] Confirm all tests continue to work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Node.js setup workflow with enhanced version handling and pnpm caching for more efficient builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->