### PR TITLE
fix: prevent TOCTOU vulnerability in PR snapshot release workflow

### DIFF
--- a/.github/workflows/pr-snapshot-release.yaml
+++ b/.github/workflows/pr-snapshot-release.yaml
@@ -71,6 +71,9 @@ jobs:
 
                 core.setFailed(errorMessage)
               }
+
+              // Set the PR head SHA as output to prevent TOCTOU attacks
+              core.setOutput('sha', pullRequest.data.head.sha)
             } catch (err) {
               core.setFailed(`Request failed with error ${err}`)
             }
@@ -82,6 +85,9 @@ jobs:
         run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pin to specific commit SHA
+        run: git checkout ${{ steps.pr_data.outputs.sha }}
 
       - name: Reset changeset entries on changeset-release/main branch
         run: |


### PR DESCRIPTION
## Summary
Severity TOCTOU (Time-of-Check Time-of-Use) vulnerability in PR snapshot release workflow.

## Changes
- Extract PR head SHA in the validation step and store it as output
- Pin checkout to the specific immutable commit SHA after branch checkout
- This prevents attackers from modifying code after security checks

## Security Impact
Before this fix, an attacker could:
1. Submit legitimate code for review
2. Get approval for snapshot release
3. Modify the code after approval but before execution

After this fix, the workflow executes code from the exact commit that was validated.

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test that snapshot release workflow completes successfully
- [ ] Confirm Code Scanning alert #26 is resolved after merge

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the reliability of the internal release process to ensure consistent artifact versioning during snapshot releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->