### PR TITLE
Potential fix for code scanning alert no. 26: Untrusted Checkout TOCTOU

### DIFF
--- a/.github/workflows/pr-snapshot-release.yaml
+++ b/.github/workflows/pr-snapshot-release.yaml
@@ -78,16 +78,11 @@ jobs:
               core.setFailed(`Request failed with error ${err}`)
             }
 
-      - name: Checkout default branch
+      - name: Checkout pull request HEAD commit
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: Checkout pull request branch
-        run: gh pr checkout ${{ github.event.issue.number }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pin to specific commit SHA
-        run: git checkout ${{ steps.pr_data.outputs.sha }}
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ steps.pr_data.outputs.sha }}
 
       - name: Reset changeset entries on changeset-release/main branch
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/kamiazya/web-csv-toolbox/security/code-scanning/26](https://github.com/kamiazya/web-csv-toolbox/security/code-scanning/26)

The proper fix is to ensure that you never check out a mutable branch or ref from a pull request, and instead always check out the verified commit SHA (immutable). Specifically:

- Replace the `gh pr checkout ${{ github.event.issue.number }}` step with a direct `actions/checkout` action that checks out the repository at the specific PR head SHA, as determined during your validation step and stored in `${{ steps.pr_data.outputs.sha }}`.
- Remove any direct mutation-prone fetches or checkouts of named branches/refs.
- If you still need the base (default) branch, keep its checkout but clearly separate it.
- Replace all steps that reference `gh pr checkout` or non-SHA ref checkout with `actions/checkout@v4` (or later) using `ref: ${{ steps.pr_data.outputs.sha }}` and `repository: ${{ github.repository }}`.
- Remove/skip the `git checkout` step that is now redundant since an exact SHA is checked out by the actions/checkout step.

No additional dependencies are needed, but you must update the workflow steps as described, making the sensitive build/release steps operate only on the validated, immutable commit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
