### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-snapshot-release.yaml
+++ b/.github/workflows/pr-snapshot-release.yaml
@@ -31,6 +31,8 @@ jobs:
   # Build the package and upload it as an artifact
   build:
     name: Build
+    permissions:
+      contents: read
     uses: ./.github/workflows/.build.yaml
     needs: check
   snapshot:


### PR DESCRIPTION
Potential fix for [https://github.com/kamiazya/web-csv-toolbox/security/code-scanning/16](https://github.com/kamiazya/web-csv-toolbox/security/code-scanning/16)

To fix this issue, add a least-privilege `permissions` block directly under the `build` job in `.github/workflows/pr-snapshot-release.yaml`. This ensures that when the job runs the referenced reusable workflow, the `GITHUB_TOKEN` will have only the specified capabilities—protecting against privilege escalation and adhering to security best practices. As a starting point, set all permissions to `read` unless you know the job requires specific `write` capabilities (in line with the recommendations), e.g.:

```yaml
permissions:
  contents: read
```
If more granular permissions are needed, you can add them; but for a generic build job, `contents: read` is usually sufficient.

Make sure you insert this block beneath `name: Build`, before `uses:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow permissions configuration for the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->