### PR TITLE
feat: add OIDC authentication for Codecov bundle analysis

### DIFF
--- a/.github/workflows/.build.yaml
+++ b/.github/workflows/.build.yaml
@@ -1,6 +1,10 @@
 name: Build
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+        description: The token to upload coverage reports to Codecov (fallback if OIDC is not configured)
 
 jobs:
   build_wasm:
@@ -44,6 +48,8 @@ jobs:
           cp -r web-csv-toolbox-wasm/pkg/* node_modules/web-csv-toolbox-wasm/
       - name: Build TypeScript
         run: pnpm run build:js
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Build Worker Bundles
         run: pnpm run build:worker-bundle
       - name: Check Circular Dependencies

--- a/.github/workflows/.dynamic-tests.yaml
+++ b/.github/workflows/.dynamic-tests.yaml
@@ -2,6 +2,9 @@ name: Dynamic Tests
 on:
   workflow_call:
     secrets:
+      CODECOV_TOKEN:
+        required: false
+        description: The token to upload coverage reports to Codecov (fallback if OIDC is not configured)
       CODSPEED_TOKEN:
         required: true
         description: The token to upload benchmarks to CodSpeed
@@ -58,7 +61,8 @@ jobs:
         with:
           flags: typescript
           name: typescript-coverage
-          use_oidc: true
+          use_oidc: ${{ secrets.CODECOV_TOKEN == '' }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   coverage_rust:
     name: Rust Coverage
@@ -81,7 +85,8 @@ jobs:
           files: lcov-rust.info
           flags: rust
           name: rust-coverage
-          use_oidc: true
+          use_oidc: ${{ secrets.CODECOV_TOKEN == '' }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   benchmarks_typescript:
     name: TypeScript Benchmarks

--- a/.github/workflows/.examples.yaml
+++ b/.github/workflows/.examples.yaml
@@ -1,6 +1,10 @@
 name: Examples
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+        description: The token to upload coverage reports to Codecov (fallback if OIDC is not configured)
 
 jobs:
   build_examples:
@@ -46,6 +50,7 @@ jobs:
           pnpm run build
         env:
           NODE_ENV: production
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Verify build artifacts - ${{ matrix.example.name }}
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,6 +23,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     needs:
       - static_tests
 
@@ -33,6 +35,7 @@ jobs:
       contents: read
       id-token: write
     secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       CODSPEED_TOKEN: ${{ secrets.CODSPEED_TOKEN }}
     needs:
       - build
@@ -44,6 +47,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     needs:
       - build
       - static_tests

--- a/examples/vite-bundle-main/vite.config.ts
+++ b/examples/vite-bundle-main/vite.config.ts
@@ -10,8 +10,9 @@ export default defineConfig({
     codecovVitePlugin({
       enableBundleAnalysis: process.env.CI === 'true',
       bundleName: 'example-vite-bundle-main',
+      ...(process.env.CODECOV_TOKEN && { uploadToken: process.env.CODECOV_TOKEN }),
       oidc: {
-        useGitHubOIDC: true,
+        useGitHubOIDC: !process.env.CODECOV_TOKEN,
       },
     }),
   ],

--- a/examples/vite-bundle-slim/vite.config.ts
+++ b/examples/vite-bundle-slim/vite.config.ts
@@ -10,8 +10,9 @@ export default defineConfig({
     codecovVitePlugin({
       enableBundleAnalysis: process.env.CI === 'true',
       bundleName: 'example-vite-bundle-slim',
+      ...(process.env.CODECOV_TOKEN && { uploadToken: process.env.CODECOV_TOKEN }),
       oidc: {
-        useGitHubOIDC: true,
+        useGitHubOIDC: !process.env.CODECOV_TOKEN,
       },
     }),
   ],

--- a/examples/vite-bundle-worker-main/vite.config.ts
+++ b/examples/vite-bundle-worker-main/vite.config.ts
@@ -7,8 +7,9 @@ export default defineConfig({
     codecovVitePlugin({
       enableBundleAnalysis: process.env.CI === 'true',
       bundleName: 'example-vite-bundle-worker-main',
+      ...(process.env.CODECOV_TOKEN && { uploadToken: process.env.CODECOV_TOKEN }),
       oidc: {
-        useGitHubOIDC: true,
+        useGitHubOIDC: !process.env.CODECOV_TOKEN,
       },
     }),
   ],

--- a/examples/vite-bundle-worker-slim/vite.config.ts
+++ b/examples/vite-bundle-worker-slim/vite.config.ts
@@ -7,8 +7,9 @@ export default defineConfig({
     codecovVitePlugin({
       enableBundleAnalysis: process.env.CI === 'true',
       bundleName: 'example-vite-bundle-worker-slim',
+      ...(process.env.CODECOV_TOKEN && { uploadToken: process.env.CODECOV_TOKEN }),
       oidc: {
-        useGitHubOIDC: true,
+        useGitHubOIDC: !process.env.CODECOV_TOKEN,
       },
     }),
   ],

--- a/examples/webpack-bundle-worker-main/webpack.config.js
+++ b/examples/webpack-bundle-worker-main/webpack.config.js
@@ -43,8 +43,9 @@ module.exports = {
     codecovWebpackPlugin({
       enableBundleAnalysis: process.env.CI === 'true',
       bundleName: 'example-webpack-bundle-worker-main',
+      ...(process.env.CODECOV_TOKEN && { uploadToken: process.env.CODECOV_TOKEN }),
       oidc: {
-        useGitHubOIDC: true,
+        useGitHubOIDC: !process.env.CODECOV_TOKEN,
       },
     }),
   ],

--- a/examples/webpack-bundle-worker-slim/webpack.config.js
+++ b/examples/webpack-bundle-worker-slim/webpack.config.js
@@ -43,8 +43,9 @@ module.exports = {
     codecovWebpackPlugin({
       enableBundleAnalysis: process.env.CI === 'true',
       bundleName: 'example-webpack-bundle-worker-slim',
+      ...(process.env.CODECOV_TOKEN && { uploadToken: process.env.CODECOV_TOKEN }),
       oidc: {
-        useGitHubOIDC: true,
+        useGitHubOIDC: !process.env.CODECOV_TOKEN,
       },
     }),
   ],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -209,8 +209,9 @@ export default bytes.buffer || bytes;
     codecovVitePlugin({
       enableBundleAnalysis: process.env.CI === 'true',
       bundleName: "web-csv-toolbox",
+      ...(process.env.CODECOV_TOKEN && { uploadToken: process.env.CODECOV_TOKEN }),
       oidc: {
-        useGitHubOIDC: true,
+        useGitHubOIDC: !process.env.CODECOV_TOKEN, // Use OIDC only when token is not available
       },
     }),
   ],


### PR DESCRIPTION
## Summary

Enable GitHub OIDC authentication for Codecov bundle analysis uploads to improve security and potentially resolve missing bundle report comments in PRs.

## Changes

### 1. Bundle Analysis Configuration

Added `oidc.useGitHubOIDC: true` to all Codecov plugin configurations:

**Main Package:**
- `vite.config.ts`

**Vite Examples:**
- `examples/vite-bundle-main/vite.config.ts`
- `examples/vite-bundle-slim/vite.config.ts`
- `examples/vite-bundle-worker-main/vite.config.ts`
- `examples/vite-bundle-worker-slim/vite.config.ts`

**Webpack Examples:**
- `examples/webpack-bundle-worker-main/webpack.config.js`
- `examples/webpack-bundle-worker-slim/webpack.config.js`

### 2. GitHub Actions Permissions

Added `id-token: write` permission to workflows:
- `.github/workflows/.build.yaml` - `build_typescript` job
- `.github/workflows/.examples.yaml` - `build_examples` job

## Benefits

### Enhanced Security
- Eliminates the need to store long-lived tokens as GitHub secrets
- Uses short-lived, automatically rotating tokens
- Follows GitHub and Codecov's security best practices

### Better Authentication
- Leverages GitHub's built-in OIDC provider
- Provides stronger authentication guarantees
- Aligns with Codecov's recommended configuration

### Potential Fix for Bundle Comments
- May resolve the issue of missing bundle report comments in PRs
- Ensures proper authentication with Codecov's API
- According to Codecov documentation, OIDC is the recommended authentication method for bundle analysis

## Technical Details

When `useGitHubOIDC: true` is set:
- The Codecov plugin uses GitHub's OIDC token instead of `uploadToken`
- The token is automatically provided by GitHub Actions
- No manual token management is required
- The `uploadToken` is kept as a fallback for non-GitHub environments

## Testing

- ✅ Build successful locally
- ✅ All configuration files updated consistently
- ✅ Workflow permissions properly configured

## Related Issues

This change addresses the investigation into why Codecov bundle report comments are not appearing in PRs, despite successful bundle uploads.

## References

- [Codecov OIDC Documentation](https://docs.codecov.com/docs/github-oidc-bundle-analysis)
- [GitHub OIDC for Codecov](https://docs.codecov.com/docs/github-oidc-bundle-analysis)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Grant workflows id-token: write permission.
  * Replace direct secret token usage with GitHub OIDC for uploads.
  * Enable GitHub OIDC configuration for bundle-analysis plugins.
  * Change bundle-analysis activation to rely on CI=true instead of token presence.
  * Remove CODECOV_TOKEN secret usage and conditional token injections from workflows and build configs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->