### PR TITLE
fix: use --cached-only flag to prevent npm registry lookups in Deno examples

### DIFF
--- a/examples/deno/main/deno.json
+++ b/examples/deno/main/deno.json
@@ -3,6 +3,6 @@
   "nodeModulesDir": "auto",
   "tasks": {
     "setup": "deno run --allow-read --allow-write setup.ts",
-    "start": "deno run --allow-read index.ts"
+    "start": "deno run --allow-read --cached-only index.ts"
   }
 }

--- a/examples/deno/slim/deno.json
+++ b/examples/deno/slim/deno.json
@@ -3,6 +3,6 @@
   "nodeModulesDir": "auto",
   "tasks": {
     "setup": "deno run --allow-read --allow-write setup.ts",
-    "start": "deno run --allow-read index.ts"
+    "start": "deno run --allow-read --cached-only index.ts"
   }
 }


### PR DESCRIPTION
## Summary

- Add `--cached-only` flag to Deno examples' start task
- This prevents Deno from querying npm registry when running examples
- setup.ts copies local build to Deno's npm cache, and `--cached-only` ensures only that cache is used

## Problem

When Version Packages PR is merged:
1. `package.json` version is updated (e.g., 0.14.0)
2. CI runs and `setup.ts` copies local build to Deno cache for version 0.14.0
3. However, `deno task start` queries npm registry for `npm:web-csv-toolbox`
4. npm returns 0.13.0 (latest published), not 0.14.0
5. Deno downloads and uses old npm version, ignoring local build
6. WASM initialization fails due to version mismatch

## Solution

Add `--cached-only` flag to prevent network requests:
```json
"start": "deno run --allow-read --cached-only index.ts"
```

This approach:
- Preserves `npm:` specifier in examples (shows real-world usage)
- Preserves `package.json` exports resolution (deno, node, browser conditions)
- Minimal change (only 2 lines modified)
- Uses existing setup.ts mechanism

## Test plan

- [x] Local test: Both main and slim examples pass with `--cached-only`
- [ ] CI: Verify Deno examples tests pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Deno start task configuration in example projects to restrict module loading to cached modules only, requiring all dependencies to be cached before execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->